### PR TITLE
setRequestStartIndex: actually set start index

### DIFF
--- a/core/include/JellyfinQt/apimodel.h
+++ b/core/include/JellyfinQt/apimodel.h
@@ -251,6 +251,8 @@ extern template void setRequestLimit(Loader::GetResumeItemsParams &params, int l
 extern template bool setRequestStartIndex(Loader::GetResumeItemsParams &params, int offset);
 extern template void setRequestLimit(Loader::GetPublicUsersParams &params, int limit);
 extern template bool setRequestStartIndex(Loader::GetPublicUsersParams &params, int offset);
+extern template void setRequestLimit(Loader::GetNextUpParams &params, int limit);
+extern template bool setRequestStartIndex(Loader::GetNextUpParams &params, int offset);
 
 extern template QList<DTO::UserDto> extractRecords(const QList<DTO::UserDto> &result);
 extern template int extractTotalRecordCount(const QList<DTO::UserDto> &result);

--- a/core/src/apimodel.cpp
+++ b/core/src/apimodel.cpp
@@ -150,7 +150,7 @@ void setRequestLimit(Loader::GetItemsByUserIdParams &params, int limit) {
 
 template<>
 bool setRequestStartIndex(Loader::GetItemsByUserIdParams &params, int index) {
-    params.setLimit(index);
+    params.setStartIndex(index);
     return true;
 }
 
@@ -161,7 +161,7 @@ void setRequestLimit(Loader::GetResumeItemsParams &params, int limit) {
 
 template<>
 bool setRequestStartIndex(Loader::GetResumeItemsParams &params, int index) {
-    params.setLimit(index);
+    params.setStartIndex(index);
     return true;
 }
 
@@ -172,6 +172,16 @@ void setRequestLimit(Loader::GetPublicUsersParams &/*params*/, int /*limit*/) {
 template<>
 bool setRequestStartIndex(Loader::GetPublicUsersParams &/*params*/, int /*offset*/) {
     return false;
+}
+
+template<>
+void setRequestLimit(Loader::GetNextUpParams &params, int limit) {
+    params.setLimit(limit);
+}
+template<>
+bool setRequestStartIndex(Loader::GetNextUpParams &params, int offset) {
+    params.setStartIndex(offset);
+    return true;
 }
 
 template<>


### PR DESCRIPTION
It previously modified the limit for some template instances. That
obviously does not work.

Additionally, setRequestStartIndex and setRequestLimit have been
implemented for GetNextUpParams.

Fixes #19