### PR TITLE
Control remote jellyfin sessions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build-*/
 # IDE files
 *.user
 CMakeLists.txt.user.*
+compile_commands.json

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -13,12 +13,14 @@ include(GNUInstallDirs)
 include(GeneratedSources.cmake)
 
 set(JellyfinQt_SOURCES
+        src/model/controllablesession.cpp
         src/model/deviceprofile.cpp
         src/model/item.cpp
         src/model/player.cpp
         src/model/playbackmanager.cpp
         src/model/playbackreporter.cpp
         src/model/playlist.cpp
+        src/model/remotejellyfinplayback.cpp
         src/model/shuffle.cpp
         src/model/user.cpp
 
@@ -32,6 +34,7 @@ set(JellyfinQt_SOURCES
         src/viewmodel/modelstatus.cpp
         src/viewmodel/playbackmanager.cpp
         src/viewmodel/playlist.cpp
+        src/viewmodel/remotedevice.cpp
         src/viewmodel/settings.cpp
         src/viewmodel/userdata.cpp
         src/viewmodel/usermodel.cpp
@@ -49,41 +52,44 @@ set(JellyfinQt_SOURCES
 list(APPEND JellyfinQt_SOURCES ${openapi_SOURCES})
 
 set(JellyfinQt_HEADERS
-        include/JellyfinQt/model/deviceprofile.h
-        include/JellyfinQt/model/item.h
-        include/JellyfinQt/model/player.h
-        include/JellyfinQt/model/playbackmanager.h
-        include/JellyfinQt/model/playbackreporter.h
-        include/JellyfinQt/model/playlist.h
-        include/JellyfinQt/model/shuffle.h
-        include/JellyfinQt/model/user.h
-        include/JellyfinQt/support/jsonconv.h
-        include/JellyfinQt/support/jsonconvimpl.h
-        include/JellyfinQt/support/loader.h
-        include/JellyfinQt/support/parseexception.h
-        include/JellyfinQt/viewmodel/item.h
-        include/JellyfinQt/viewmodel/itemmodel.h
-        include/JellyfinQt/viewmodel/loader.h
-        include/JellyfinQt/viewmodel/mediastream.h
-        include/JellyfinQt/viewmodel/modelstatus.h
-        include/JellyfinQt/viewmodel/propertyhelper.h
-        include/JellyfinQt/viewmodel/playbackmanager.h
-        include/JellyfinQt/viewmodel/platformmediacontrol.h
-        include/JellyfinQt/viewmodel/playlist.h
-        include/JellyfinQt/viewmodel/settings.h
-        include/JellyfinQt/viewmodel/userdata.h
-        include/JellyfinQt/viewmodel/usermodel.h
-        include/JellyfinQt/viewmodel/user.h
-        include/JellyfinQt/viewmodel/utils.h
-        include/JellyfinQt/apiclient.h
-        include/JellyfinQt/apimodel.h
-        include/JellyfinQt/credentialmanager.h
-        include/JellyfinQt/eventbus.h
-        include/JellyfinQt/jellyfin.h
-        include/JellyfinQt/jsonhelper.h
-        include/JellyfinQt/qobjectsettingswrapper.h
-        include/JellyfinQt/serverdiscoverymodel.h
-        include/JellyfinQt/websocket.h)
+    include/JellyfinQt/model/controllablesession.h
+    include/JellyfinQt/model/deviceprofile.h
+    include/JellyfinQt/model/item.h
+    include/JellyfinQt/model/player.h
+    include/JellyfinQt/model/playbackmanager.h
+    include/JellyfinQt/model/playbackreporter.h
+    include/JellyfinQt/model/playlist.h
+    include/JellyfinQt/model/remotejellyfinplayback.h
+    include/JellyfinQt/model/shuffle.h
+    include/JellyfinQt/model/user.h
+    include/JellyfinQt/support/jsonconv.h
+    include/JellyfinQt/support/jsonconvimpl.h
+    include/JellyfinQt/support/loader.h
+    include/JellyfinQt/support/parseexception.h
+    include/JellyfinQt/viewmodel/item.h
+    include/JellyfinQt/viewmodel/itemmodel.h
+    include/JellyfinQt/viewmodel/loader.h
+    include/JellyfinQt/viewmodel/mediastream.h
+    include/JellyfinQt/viewmodel/modelstatus.h
+    include/JellyfinQt/viewmodel/propertyhelper.h
+    include/JellyfinQt/viewmodel/playbackmanager.h
+    include/JellyfinQt/viewmodel/platformmediacontrol.h
+    include/JellyfinQt/viewmodel/playlist.h
+    include/JellyfinQt/viewmodel/remotedevice.h
+    include/JellyfinQt/viewmodel/settings.h
+    include/JellyfinQt/viewmodel/userdata.h
+    include/JellyfinQt/viewmodel/usermodel.h
+    include/JellyfinQt/viewmodel/user.h
+    include/JellyfinQt/viewmodel/utils.h
+    include/JellyfinQt/apiclient.h
+    include/JellyfinQt/apimodel.h
+    include/JellyfinQt/credentialmanager.h
+    include/JellyfinQt/eventbus.h
+    include/JellyfinQt/jellyfin.h
+    include/JellyfinQt/jsonhelper.h
+    include/JellyfinQt/qobjectsettingswrapper.h
+    include/JellyfinQt/serverdiscoverymodel.h
+    include/JellyfinQt/websocket.h)
 
 if (FREEDESKTOP_INTEGRATION)
     list(APPEND JellyfinQt_SOURCES

--- a/core/include/JellyfinQt/apiclient.h
+++ b/core/include/JellyfinQt/apiclient.h
@@ -96,6 +96,7 @@ public:
     explicit ApiClient(QObject *parent = nullptr);
     virtual ~ApiClient();
     Q_PROPERTY(QString baseUrl READ baseUrl WRITE setBaseUrl NOTIFY baseUrlChanged)
+    Q_PROPERTY(QString appName READ appName WRITE setAppName NOTIFY appNameChanged)
     Q_PROPERTY(bool authenticated READ authenticated WRITE setAuthenticated NOTIFY authenticatedChanged)
     Q_PROPERTY(QString userId READ userId NOTIFY userIdChanged)
     Q_PROPERTY(QJsonObject deviceProfile READ deviceProfileJson NOTIFY deviceProfileChanged)
@@ -114,6 +115,7 @@ public:
 
     bool authenticated() const;
     void setBaseUrl(const QString &url);
+    void setAppName(const QString &appName);
     QNetworkReply *get(const QString &path, const QUrlQuery &params = QUrlQuery());
     QNetworkReply *post(const QString &path, const QJsonDocument &data, const QUrlQuery &params = QUrlQuery());
     QNetworkReply *post(const QString &path, const QByteArray &data = QByteArray(), const QUrlQuery &params = QUrlQuery());
@@ -127,6 +129,7 @@ public:
     Q_ENUM(ApiError)
 
     const QString &baseUrl() const;
+    const QString &appName() const;
     const QString &userId() const;
     const QString &deviceId() const;
     /**
@@ -185,6 +188,7 @@ signals:
 
     void authenticatedChanged(bool authenticated);
     void baseUrlChanged(const QString &baseUrl);
+    void appNameChanged(const QString &newAppName);
     void settingsChanged();
 
     /**

--- a/core/include/JellyfinQt/apiclient.h
+++ b/core/include/JellyfinQt/apiclient.h
@@ -41,6 +41,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include "dto/generalcommandtype.h"
 #include "credentialmanager.h"
+#include "model/controllablesession.h"
 #include "model/deviceprofile.h"
 #include "eventbus.h"
 
@@ -97,6 +98,7 @@ public:
     virtual ~ApiClient();
     Q_PROPERTY(QString baseUrl READ baseUrl WRITE setBaseUrl NOTIFY baseUrlChanged)
     Q_PROPERTY(QString appName READ appName WRITE setAppName NOTIFY appNameChanged)
+    Q_PROPERTY(Jellyfin::Model::DeviceTypeClass::Value deviceType READ deviceType WRITE setDeviceType NOTIFY deviceTypeChanged)
     Q_PROPERTY(bool authenticated READ authenticated WRITE setAuthenticated NOTIFY authenticatedChanged)
     Q_PROPERTY(QString userId READ userId NOTIFY userIdChanged)
     Q_PROPERTY(QJsonObject deviceProfile READ deviceProfileJson NOTIFY deviceProfileChanged)
@@ -116,6 +118,8 @@ public:
     bool authenticated() const;
     void setBaseUrl(const QString &url);
     void setAppName(const QString &appName);
+    void setDeviceType(Model::DeviceType deviceType);
+
     QNetworkReply *get(const QString &path, const QUrlQuery &params = QUrlQuery());
     QNetworkReply *post(const QString &path, const QJsonDocument &data, const QUrlQuery &params = QUrlQuery());
     QNetworkReply *post(const QString &path, const QByteArray &data = QByteArray(), const QUrlQuery &params = QUrlQuery());
@@ -132,6 +136,7 @@ public:
     const QString &appName() const;
     const QString &userId() const;
     const QString &deviceId() const;
+    Model::DeviceType deviceType() const;
     /**
      * @brief QML applications can set this type to indicate which commands they support.
      *
@@ -200,6 +205,7 @@ signals:
     void userIdChanged(QString userId);
 
     void deviceProfileChanged();
+    void deviceTypeChanged();
 
     void supportedCommandsChanged();
     void onlineChanged();

--- a/core/include/JellyfinQt/eventbus.h
+++ b/core/include/JellyfinQt/eventbus.h
@@ -26,6 +26,7 @@ namespace Jellyfin {
 namespace DTO {
     class UserItemDataDto;
     class PlaystateRequest;
+    class SessionInfo;
 }
 
 /**
@@ -43,6 +44,13 @@ signals:
      * @param userData The new userData
      */
     void itemUserDataUpdated(const QString &itemId, const DTO::UserItemDataDto &userData);
+
+    /**
+     * @brief The information about a session has been updated
+     * @param sessionId The id of the session
+     * @param sessionInfo The associated information
+     */
+    void sessionInfoUpdated(const QString &sessionId, const DTO::SessionInfo &sessionInfo);
 
     /**
      * @brief The server has requested to display an message to the user

--- a/core/include/JellyfinQt/loader/http/apikey.h
+++ b/core/include/JellyfinQt/loader/http/apikey.h
@@ -61,6 +61,34 @@ protected:
 	QByteArray body(const GetKeysParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Create a new api key.
+ */
+
+class CreateKeyLoader : public Jellyfin::Support::HttpLoader<void, CreateKeyParams> {
+public:
+	explicit CreateKeyLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CreateKeyParams& parameters) const override;
+	QUrlQuery query(const CreateKeyParams& parameters) const override;
+	QByteArray body(const CreateKeyParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Remove an api key.
+ */
+
+class RevokeKeyLoader : public Jellyfin::Support::HttpLoader<void, RevokeKeyParams> {
+public:
+	explicit RevokeKeyLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RevokeKeyParams& parameters) const override;
+	QUrlQuery query(const RevokeKeyParams& parameters) const override;
+	QByteArray body(const RevokeKeyParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/branding.h
+++ b/core/include/JellyfinQt/loader/http/branding.h
@@ -65,7 +65,7 @@ protected:
  * @brief Gets branding css.
  */
 
-class GetBrandingCssLoader : public Jellyfin::Support::HttpLoader<QString, GetBrandingCssParams> {
+class GetBrandingCssLoader : public Jellyfin::Support::HttpLoader<void, GetBrandingCssParams> {
 public:
 	explicit GetBrandingCssLoader(ApiClient *apiClient = nullptr);
 
@@ -79,7 +79,7 @@ protected:
  * @brief Gets branding css.
  */
 
-class GetBrandingCss_2Loader : public Jellyfin::Support::HttpLoader<QString, GetBrandingCss_2Params> {
+class GetBrandingCss_2Loader : public Jellyfin::Support::HttpLoader<void, GetBrandingCss_2Params> {
 public:
 	explicit GetBrandingCss_2Loader(ApiClient *apiClient = nullptr);
 

--- a/core/include/JellyfinQt/loader/http/collection.h
+++ b/core/include/JellyfinQt/loader/http/collection.h
@@ -61,6 +61,34 @@ protected:
 	QByteArray body(const CreateCollectionParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Adds items to a collection.
+ */
+
+class AddToCollectionLoader : public Jellyfin::Support::HttpLoader<void, AddToCollectionParams> {
+public:
+	explicit AddToCollectionLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const AddToCollectionParams& parameters) const override;
+	QUrlQuery query(const AddToCollectionParams& parameters) const override;
+	QByteArray body(const AddToCollectionParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Removes items from a collection.
+ */
+
+class RemoveFromCollectionLoader : public Jellyfin::Support::HttpLoader<void, RemoveFromCollectionParams> {
+public:
+	explicit RemoveFromCollectionLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RemoveFromCollectionParams& parameters) const override;
+	QUrlQuery query(const RemoveFromCollectionParams& parameters) const override;
+	QByteArray body(const RemoveFromCollectionParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/configuration.h
+++ b/core/include/JellyfinQt/loader/http/configuration.h
@@ -63,6 +63,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Updates application configuration.
+ */
+
+class UpdateConfigurationLoader : public Jellyfin::Support::HttpLoader<void, UpdateConfigurationParams> {
+public:
+	explicit UpdateConfigurationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateConfigurationParams& parameters) const override;
+	QUrlQuery query(const UpdateConfigurationParams& parameters) const override;
+	QByteArray body(const UpdateConfigurationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets a named configuration.
  */
 
@@ -77,6 +91,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Updates named configuration.
+ */
+
+class UpdateNamedConfigurationLoader : public Jellyfin::Support::HttpLoader<void, UpdateNamedConfigurationParams> {
+public:
+	explicit UpdateNamedConfigurationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateNamedConfigurationParams& parameters) const override;
+	QUrlQuery query(const UpdateNamedConfigurationParams& parameters) const override;
+	QByteArray body(const UpdateNamedConfigurationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets a default MetadataOptions object.
  */
 
@@ -88,6 +116,20 @@ protected:
 	QString path(const GetDefaultMetadataOptionsParams& parameters) const override;
 	QUrlQuery query(const GetDefaultMetadataOptionsParams& parameters) const override;
 	QByteArray body(const GetDefaultMetadataOptionsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates the path to the media encoder.
+ */
+
+class UpdateMediaEncoderPathLoader : public Jellyfin::Support::HttpLoader<void, UpdateMediaEncoderPathParams> {
+public:
+	explicit UpdateMediaEncoderPathLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateMediaEncoderPathParams& parameters) const override;
+	QUrlQuery query(const UpdateMediaEncoderPathParams& parameters) const override;
+	QByteArray body(const UpdateMediaEncoderPathParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/devices.h
+++ b/core/include/JellyfinQt/loader/http/devices.h
@@ -64,6 +64,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Deletes a device.
+ */
+
+class DeleteDeviceLoader : public Jellyfin::Support::HttpLoader<void, DeleteDeviceParams> {
+public:
+	explicit DeleteDeviceLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteDeviceParams& parameters) const override;
+	QUrlQuery query(const DeleteDeviceParams& parameters) const override;
+	QByteArray body(const DeleteDeviceParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Get info for a device.
  */
 
@@ -89,6 +103,20 @@ protected:
 	QString path(const GetDeviceOptionsParams& parameters) const override;
 	QUrlQuery query(const GetDeviceOptionsParams& parameters) const override;
 	QByteArray body(const GetDeviceOptionsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Update device options.
+ */
+
+class UpdateDeviceOptionsLoader : public Jellyfin::Support::HttpLoader<void, UpdateDeviceOptionsParams> {
+public:
+	explicit UpdateDeviceOptionsLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateDeviceOptionsParams& parameters) const override;
+	QUrlQuery query(const UpdateDeviceOptionsParams& parameters) const override;
+	QByteArray body(const UpdateDeviceOptionsParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/displaypreferences.h
+++ b/core/include/JellyfinQt/loader/http/displaypreferences.h
@@ -61,6 +61,20 @@ protected:
 	QByteArray body(const GetDisplayPreferencesParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Update Display Preferences.
+ */
+
+class UpdateDisplayPreferencesLoader : public Jellyfin::Support::HttpLoader<void, UpdateDisplayPreferencesParams> {
+public:
+	explicit UpdateDisplayPreferencesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateDisplayPreferencesParams& parameters) const override;
+	QUrlQuery query(const UpdateDisplayPreferencesParams& parameters) const override;
+	QByteArray body(const UpdateDisplayPreferencesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/dlna.h
+++ b/core/include/JellyfinQt/loader/http/dlna.h
@@ -64,6 +64,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Creates a profile.
+ */
+
+class CreateProfileLoader : public Jellyfin::Support::HttpLoader<void, CreateProfileParams> {
+public:
+	explicit CreateProfileLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CreateProfileParams& parameters) const override;
+	QUrlQuery query(const CreateProfileParams& parameters) const override;
+	QByteArray body(const CreateProfileParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets a single profile.
  */
 
@@ -75,6 +89,34 @@ protected:
 	QString path(const GetProfileParams& parameters) const override;
 	QUrlQuery query(const GetProfileParams& parameters) const override;
 	QByteArray body(const GetProfileParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Deletes a profile.
+ */
+
+class DeleteProfileLoader : public Jellyfin::Support::HttpLoader<void, DeleteProfileParams> {
+public:
+	explicit DeleteProfileLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteProfileParams& parameters) const override;
+	QUrlQuery query(const DeleteProfileParams& parameters) const override;
+	QByteArray body(const DeleteProfileParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a profile.
+ */
+
+class UpdateProfileLoader : public Jellyfin::Support::HttpLoader<void, UpdateProfileParams> {
+public:
+	explicit UpdateProfileLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateProfileParams& parameters) const override;
+	QUrlQuery query(const UpdateProfileParams& parameters) const override;
+	QByteArray body(const UpdateProfileParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**

--- a/core/include/JellyfinQt/loader/http/environment.h
+++ b/core/include/JellyfinQt/loader/http/environment.h
@@ -120,6 +120,20 @@ protected:
 	QByteArray body(const GetParentPathParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Validates path.
+ */
+
+class ValidatePathLoader : public Jellyfin::Support::HttpLoader<void, ValidatePathParams> {
+public:
+	explicit ValidatePathLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ValidatePathParams& parameters) const override;
+	QUrlQuery query(const ValidatePathParams& parameters) const override;
+	QByteArray body(const ValidatePathParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/hlssegment.h
+++ b/core/include/JellyfinQt/loader/http/hlssegment.h
@@ -46,6 +46,20 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+/**
+ * @brief Stops an active encoding.
+ */
+
+class StopEncodingProcessLoader : public Jellyfin::Support::HttpLoader<void, StopEncodingProcessParams> {
+public:
+	explicit StopEncodingProcessLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const StopEncodingProcessParams& parameters) const override;
+	QUrlQuery query(const StopEncodingProcessParams& parameters) const override;
+	QByteArray body(const StopEncodingProcessParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/image.h
+++ b/core/include/JellyfinQt/loader/http/image.h
@@ -61,6 +61,132 @@ protected:
 	QByteArray body(const GetItemImageInfosParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Delete an item's image.
+ */
+
+class DeleteItemImageLoader : public Jellyfin::Support::HttpLoader<void, DeleteItemImageParams> {
+public:
+	explicit DeleteItemImageLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteItemImageParams& parameters) const override;
+	QUrlQuery query(const DeleteItemImageParams& parameters) const override;
+	QByteArray body(const DeleteItemImageParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Set item image.
+ */
+
+class SetItemImageLoader : public Jellyfin::Support::HttpLoader<void, SetItemImageParams> {
+public:
+	explicit SetItemImageLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SetItemImageParams& parameters) const override;
+	QUrlQuery query(const SetItemImageParams& parameters) const override;
+	QByteArray body(const SetItemImageParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Delete an item's image.
+ */
+
+class DeleteItemImageByIndexLoader : public Jellyfin::Support::HttpLoader<void, DeleteItemImageByIndexParams> {
+public:
+	explicit DeleteItemImageByIndexLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteItemImageByIndexParams& parameters) const override;
+	QUrlQuery query(const DeleteItemImageByIndexParams& parameters) const override;
+	QByteArray body(const DeleteItemImageByIndexParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Set item image.
+ */
+
+class SetItemImageByIndexLoader : public Jellyfin::Support::HttpLoader<void, SetItemImageByIndexParams> {
+public:
+	explicit SetItemImageByIndexLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SetItemImageByIndexParams& parameters) const override;
+	QUrlQuery query(const SetItemImageByIndexParams& parameters) const override;
+	QByteArray body(const SetItemImageByIndexParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates the index for an item image.
+ */
+
+class UpdateItemImageIndexLoader : public Jellyfin::Support::HttpLoader<void, UpdateItemImageIndexParams> {
+public:
+	explicit UpdateItemImageIndexLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateItemImageIndexParams& parameters) const override;
+	QUrlQuery query(const UpdateItemImageIndexParams& parameters) const override;
+	QByteArray body(const UpdateItemImageIndexParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Sets the user image.
+ */
+
+class PostUserImageLoader : public Jellyfin::Support::HttpLoader<void, PostUserImageParams> {
+public:
+	explicit PostUserImageLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostUserImageParams& parameters) const override;
+	QUrlQuery query(const PostUserImageParams& parameters) const override;
+	QByteArray body(const PostUserImageParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Delete the user's image.
+ */
+
+class DeleteUserImageLoader : public Jellyfin::Support::HttpLoader<void, DeleteUserImageParams> {
+public:
+	explicit DeleteUserImageLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteUserImageParams& parameters) const override;
+	QUrlQuery query(const DeleteUserImageParams& parameters) const override;
+	QByteArray body(const DeleteUserImageParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Sets the user image.
+ */
+
+class PostUserImageByIndexLoader : public Jellyfin::Support::HttpLoader<void, PostUserImageByIndexParams> {
+public:
+	explicit PostUserImageByIndexLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostUserImageByIndexParams& parameters) const override;
+	QUrlQuery query(const PostUserImageByIndexParams& parameters) const override;
+	QByteArray body(const PostUserImageByIndexParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Delete the user's image.
+ */
+
+class DeleteUserImageByIndexLoader : public Jellyfin::Support::HttpLoader<void, DeleteUserImageByIndexParams> {
+public:
+	explicit DeleteUserImageByIndexLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteUserImageByIndexParams& parameters) const override;
+	QUrlQuery query(const DeleteUserImageByIndexParams& parameters) const override;
+	QByteArray body(const DeleteUserImageByIndexParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/itemlookup.h
+++ b/core/include/JellyfinQt/loader/http/itemlookup.h
@@ -71,6 +71,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Applies search criteria to an item and refreshes metadata.
+ */
+
+class ApplySearchCriteriaLoader : public Jellyfin::Support::HttpLoader<void, ApplySearchCriteriaParams> {
+public:
+	explicit ApplySearchCriteriaLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ApplySearchCriteriaParams& parameters) const override;
+	QUrlQuery query(const ApplySearchCriteriaParams& parameters) const override;
+	QByteArray body(const ApplySearchCriteriaParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Get book remote search.
  */
 

--- a/core/include/JellyfinQt/loader/http/itemrefresh.h
+++ b/core/include/JellyfinQt/loader/http/itemrefresh.h
@@ -46,6 +46,20 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+/**
+ * @brief Refreshes metadata for an item.
+ */
+
+class PostLoader : public Jellyfin::Support::HttpLoader<void, PostParams> {
+public:
+	explicit PostLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostParams& parameters) const override;
+	QUrlQuery query(const PostParams& parameters) const override;
+	QByteArray body(const PostParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/itemupdate.h
+++ b/core/include/JellyfinQt/loader/http/itemupdate.h
@@ -48,6 +48,34 @@ namespace HTTP {
 using namespace Jellyfin::DTO;
 
 /**
+ * @brief Updates an item.
+ */
+
+class UpdateItemLoader : public Jellyfin::Support::HttpLoader<void, UpdateItemParams> {
+public:
+	explicit UpdateItemLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateItemParams& parameters) const override;
+	QUrlQuery query(const UpdateItemParams& parameters) const override;
+	QByteArray body(const UpdateItemParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates an item's content type.
+ */
+
+class UpdateItemContentTypeLoader : public Jellyfin::Support::HttpLoader<void, UpdateItemContentTypeParams> {
+public:
+	explicit UpdateItemContentTypeLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateItemContentTypeParams& parameters) const override;
+	QUrlQuery query(const UpdateItemContentTypeParams& parameters) const override;
+	QByteArray body(const UpdateItemContentTypeParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets metadata editor info for an item.
  */
 

--- a/core/include/JellyfinQt/loader/http/library.h
+++ b/core/include/JellyfinQt/loader/http/library.h
@@ -62,6 +62,34 @@ namespace HTTP {
 using namespace Jellyfin::DTO;
 
 /**
+ * @brief Deletes items from the library and filesystem.
+ */
+
+class DeleteItemsLoader : public Jellyfin::Support::HttpLoader<void, DeleteItemsParams> {
+public:
+	explicit DeleteItemsLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteItemsParams& parameters) const override;
+	QUrlQuery query(const DeleteItemsParams& parameters) const override;
+	QByteArray body(const DeleteItemsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Deletes an item from the library and filesystem.
+ */
+
+class DeleteItemLoader : public Jellyfin::Support::HttpLoader<void, DeleteItemParams> {
+public:
+	explicit DeleteItemLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteItemParams& parameters) const override;
+	QUrlQuery query(const DeleteItemParams& parameters) const override;
+	QByteArray body(const DeleteItemParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets similar items.
  */
 
@@ -202,6 +230,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Reports that new movies have been added by an external source.
+ */
+
+class PostUpdatedMediaLoader : public Jellyfin::Support::HttpLoader<void, PostUpdatedMediaParams> {
+public:
+	explicit PostUpdatedMediaLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostUpdatedMediaParams& parameters) const override;
+	QUrlQuery query(const PostUpdatedMediaParams& parameters) const override;
+	QByteArray body(const PostUpdatedMediaParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets all user media folders.
  */
 
@@ -216,6 +258,34 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Reports that new movies have been added by an external source.
+ */
+
+class PostAddedMoviesLoader : public Jellyfin::Support::HttpLoader<void, PostAddedMoviesParams> {
+public:
+	explicit PostAddedMoviesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostAddedMoviesParams& parameters) const override;
+	QUrlQuery query(const PostAddedMoviesParams& parameters) const override;
+	QByteArray body(const PostAddedMoviesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports that new movies have been added by an external source.
+ */
+
+class PostUpdatedMoviesLoader : public Jellyfin::Support::HttpLoader<void, PostUpdatedMoviesParams> {
+public:
+	explicit PostUpdatedMoviesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostUpdatedMoviesParams& parameters) const override;
+	QUrlQuery query(const PostUpdatedMoviesParams& parameters) const override;
+	QByteArray body(const PostUpdatedMoviesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets a list of physical paths from virtual folders.
  */
 
@@ -227,6 +297,48 @@ protected:
 	QString path(const GetPhysicalPathsParams& parameters) const override;
 	QUrlQuery query(const GetPhysicalPathsParams& parameters) const override;
 	QByteArray body(const GetPhysicalPathsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Starts a library scan.
+ */
+
+class RefreshLibraryLoader : public Jellyfin::Support::HttpLoader<void, RefreshLibraryParams> {
+public:
+	explicit RefreshLibraryLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RefreshLibraryParams& parameters) const override;
+	QUrlQuery query(const RefreshLibraryParams& parameters) const override;
+	QByteArray body(const RefreshLibraryParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports that new episodes of a series have been added by an external source.
+ */
+
+class PostAddedSeriesLoader : public Jellyfin::Support::HttpLoader<void, PostAddedSeriesParams> {
+public:
+	explicit PostAddedSeriesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostAddedSeriesParams& parameters) const override;
+	QUrlQuery query(const PostAddedSeriesParams& parameters) const override;
+	QByteArray body(const PostAddedSeriesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports that new episodes of a series have been added by an external source.
+ */
+
+class PostUpdatedSeriesLoader : public Jellyfin::Support::HttpLoader<void, PostUpdatedSeriesParams> {
+public:
+	explicit PostUpdatedSeriesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostUpdatedSeriesParams& parameters) const override;
+	QUrlQuery query(const PostUpdatedSeriesParams& parameters) const override;
+	QByteArray body(const PostUpdatedSeriesParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**

--- a/core/include/JellyfinQt/loader/http/librarystructure.h
+++ b/core/include/JellyfinQt/loader/http/librarystructure.h
@@ -61,6 +61,104 @@ protected:
 	QByteArray body(const GetVirtualFoldersParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Adds a virtual folder.
+ */
+
+class AddVirtualFolderLoader : public Jellyfin::Support::HttpLoader<void, AddVirtualFolderParams> {
+public:
+	explicit AddVirtualFolderLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const AddVirtualFolderParams& parameters) const override;
+	QUrlQuery query(const AddVirtualFolderParams& parameters) const override;
+	QByteArray body(const AddVirtualFolderParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Removes a virtual folder.
+ */
+
+class RemoveVirtualFolderLoader : public Jellyfin::Support::HttpLoader<void, RemoveVirtualFolderParams> {
+public:
+	explicit RemoveVirtualFolderLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RemoveVirtualFolderParams& parameters) const override;
+	QUrlQuery query(const RemoveVirtualFolderParams& parameters) const override;
+	QByteArray body(const RemoveVirtualFolderParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Update library options.
+ */
+
+class UpdateLibraryOptionsLoader : public Jellyfin::Support::HttpLoader<void, UpdateLibraryOptionsParams> {
+public:
+	explicit UpdateLibraryOptionsLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateLibraryOptionsParams& parameters) const override;
+	QUrlQuery query(const UpdateLibraryOptionsParams& parameters) const override;
+	QByteArray body(const UpdateLibraryOptionsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Renames a virtual folder.
+ */
+
+class RenameVirtualFolderLoader : public Jellyfin::Support::HttpLoader<void, RenameVirtualFolderParams> {
+public:
+	explicit RenameVirtualFolderLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RenameVirtualFolderParams& parameters) const override;
+	QUrlQuery query(const RenameVirtualFolderParams& parameters) const override;
+	QByteArray body(const RenameVirtualFolderParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Add a media path to a library.
+ */
+
+class AddMediaPathLoader : public Jellyfin::Support::HttpLoader<void, AddMediaPathParams> {
+public:
+	explicit AddMediaPathLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const AddMediaPathParams& parameters) const override;
+	QUrlQuery query(const AddMediaPathParams& parameters) const override;
+	QByteArray body(const AddMediaPathParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Remove a media path.
+ */
+
+class RemoveMediaPathLoader : public Jellyfin::Support::HttpLoader<void, RemoveMediaPathParams> {
+public:
+	explicit RemoveMediaPathLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RemoveMediaPathParams& parameters) const override;
+	QUrlQuery query(const RemoveMediaPathParams& parameters) const override;
+	QByteArray body(const RemoveMediaPathParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a media path.
+ */
+
+class UpdateMediaPathLoader : public Jellyfin::Support::HttpLoader<void, UpdateMediaPathParams> {
+public:
+	explicit UpdateMediaPathLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateMediaPathParams& parameters) const override;
+	QUrlQuery query(const UpdateMediaPathParams& parameters) const override;
+	QByteArray body(const UpdateMediaPathParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/livetv.h
+++ b/core/include/JellyfinQt/loader/http/livetv.h
@@ -172,6 +172,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Delete listing provider.
+ */
+
+class DeleteListingProviderLoader : public Jellyfin::Support::HttpLoader<void, DeleteListingProviderParams> {
+public:
+	explicit DeleteListingProviderLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteListingProviderParams& parameters) const override;
+	QUrlQuery query(const DeleteListingProviderParams& parameters) const override;
+	QByteArray body(const DeleteListingProviderParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets default listings provider info.
  */
 
@@ -298,6 +312,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Deletes a live tv recording.
+ */
+
+class DeleteRecordingLoader : public Jellyfin::Support::HttpLoader<void, DeleteRecordingParams> {
+public:
+	explicit DeleteRecordingLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteRecordingParams& parameters) const override;
+	QUrlQuery query(const DeleteRecordingParams& parameters) const override;
+	QByteArray body(const DeleteRecordingParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets recording folders.
  */
 
@@ -354,6 +382,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Creates a live tv series timer.
+ */
+
+class CreateSeriesTimerLoader : public Jellyfin::Support::HttpLoader<void, CreateSeriesTimerParams> {
+public:
+	explicit CreateSeriesTimerLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CreateSeriesTimerParams& parameters) const override;
+	QUrlQuery query(const CreateSeriesTimerParams& parameters) const override;
+	QByteArray body(const CreateSeriesTimerParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets a live tv series timer.
  */
 
@@ -365,6 +407,34 @@ protected:
 	QString path(const GetSeriesTimerParams& parameters) const override;
 	QUrlQuery query(const GetSeriesTimerParams& parameters) const override;
 	QByteArray body(const GetSeriesTimerParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Cancels a live tv series timer.
+ */
+
+class CancelSeriesTimerLoader : public Jellyfin::Support::HttpLoader<void, CancelSeriesTimerParams> {
+public:
+	explicit CancelSeriesTimerLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CancelSeriesTimerParams& parameters) const override;
+	QUrlQuery query(const CancelSeriesTimerParams& parameters) const override;
+	QByteArray body(const CancelSeriesTimerParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a live tv series timer.
+ */
+
+class UpdateSeriesTimerLoader : public Jellyfin::Support::HttpLoader<void, UpdateSeriesTimerParams> {
+public:
+	explicit UpdateSeriesTimerLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateSeriesTimerParams& parameters) const override;
+	QUrlQuery query(const UpdateSeriesTimerParams& parameters) const override;
+	QByteArray body(const UpdateSeriesTimerParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
@@ -382,6 +452,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Creates a live tv timer.
+ */
+
+class CreateTimerLoader : public Jellyfin::Support::HttpLoader<void, CreateTimerParams> {
+public:
+	explicit CreateTimerLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CreateTimerParams& parameters) const override;
+	QUrlQuery query(const CreateTimerParams& parameters) const override;
+	QByteArray body(const CreateTimerParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets a timer.
  */
 
@@ -393,6 +477,34 @@ protected:
 	QString path(const GetTimerParams& parameters) const override;
 	QUrlQuery query(const GetTimerParams& parameters) const override;
 	QByteArray body(const GetTimerParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Cancels a live tv timer.
+ */
+
+class CancelTimerLoader : public Jellyfin::Support::HttpLoader<void, CancelTimerParams> {
+public:
+	explicit CancelTimerLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CancelTimerParams& parameters) const override;
+	QUrlQuery query(const CancelTimerParams& parameters) const override;
+	QByteArray body(const CancelTimerParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a live tv timer.
+ */
+
+class UpdateTimerLoader : public Jellyfin::Support::HttpLoader<void, UpdateTimerParams> {
+public:
+	explicit UpdateTimerLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateTimerParams& parameters) const override;
+	QUrlQuery query(const UpdateTimerParams& parameters) const override;
+	QByteArray body(const UpdateTimerParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
@@ -424,6 +536,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Deletes a tuner host.
+ */
+
+class DeleteTunerHostLoader : public Jellyfin::Support::HttpLoader<void, DeleteTunerHostParams> {
+public:
+	explicit DeleteTunerHostLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteTunerHostParams& parameters) const override;
+	QUrlQuery query(const DeleteTunerHostParams& parameters) const override;
+	QByteArray body(const DeleteTunerHostParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Get tuner host types.
  */
 
@@ -435,6 +561,20 @@ protected:
 	QString path(const GetTunerHostTypesParams& parameters) const override;
 	QUrlQuery query(const GetTunerHostTypesParams& parameters) const override;
 	QByteArray body(const GetTunerHostTypesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Resets a tv tuner.
+ */
+
+class ResetTunerLoader : public Jellyfin::Support::HttpLoader<void, ResetTunerParams> {
+public:
+	explicit ResetTunerLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ResetTunerParams& parameters) const override;
+	QUrlQuery query(const ResetTunerParams& parameters) const override;
+	QByteArray body(const ResetTunerParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**

--- a/core/include/JellyfinQt/loader/http/mediainfo.h
+++ b/core/include/JellyfinQt/loader/http/mediainfo.h
@@ -78,6 +78,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Closes a media source.
+ */
+
+class CloseLiveStreamLoader : public Jellyfin::Support::HttpLoader<void, CloseLiveStreamParams> {
+public:
+	explicit CloseLiveStreamLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CloseLiveStreamParams& parameters) const override;
+	QUrlQuery query(const CloseLiveStreamParams& parameters) const override;
+	QByteArray body(const CloseLiveStreamParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Opens a media source.
  */
 

--- a/core/include/JellyfinQt/loader/http/notifications.h
+++ b/core/include/JellyfinQt/loader/http/notifications.h
@@ -65,6 +65,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Sets notifications as read.
+ */
+
+class SetReadLoader : public Jellyfin::Support::HttpLoader<void, SetReadParams> {
+public:
+	explicit SetReadLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SetReadParams& parameters) const override;
+	QUrlQuery query(const SetReadParams& parameters) const override;
+	QByteArray body(const SetReadParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets a user's notification summary.
  */
 
@@ -76,6 +90,34 @@ protected:
 	QString path(const GetNotificationsSummaryParams& parameters) const override;
 	QUrlQuery query(const GetNotificationsSummaryParams& parameters) const override;
 	QByteArray body(const GetNotificationsSummaryParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Sets notifications as unread.
+ */
+
+class SetUnreadLoader : public Jellyfin::Support::HttpLoader<void, SetUnreadParams> {
+public:
+	explicit SetUnreadLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SetUnreadParams& parameters) const override;
+	QUrlQuery query(const SetUnreadParams& parameters) const override;
+	QByteArray body(const SetUnreadParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Sends a notification to all admins.
+ */
+
+class CreateAdminNotificationLoader : public Jellyfin::Support::HttpLoader<void, CreateAdminNotificationParams> {
+public:
+	explicit CreateAdminNotificationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CreateAdminNotificationParams& parameters) const override;
+	QUrlQuery query(const CreateAdminNotificationParams& parameters) const override;
+	QByteArray body(const CreateAdminNotificationParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**

--- a/core/include/JellyfinQt/loader/http/package.h
+++ b/core/include/JellyfinQt/loader/http/package.h
@@ -78,6 +78,34 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Installs a package.
+ */
+
+class InstallPackageLoader : public Jellyfin::Support::HttpLoader<void, InstallPackageParams> {
+public:
+	explicit InstallPackageLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const InstallPackageParams& parameters) const override;
+	QUrlQuery query(const InstallPackageParams& parameters) const override;
+	QByteArray body(const InstallPackageParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Cancels a package installation.
+ */
+
+class CancelPackageInstallationLoader : public Jellyfin::Support::HttpLoader<void, CancelPackageInstallationParams> {
+public:
+	explicit CancelPackageInstallationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CancelPackageInstallationParams& parameters) const override;
+	QUrlQuery query(const CancelPackageInstallationParams& parameters) const override;
+	QByteArray body(const CancelPackageInstallationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets all package repositories.
  */
 
@@ -89,6 +117,20 @@ protected:
 	QString path(const GetRepositoriesParams& parameters) const override;
 	QUrlQuery query(const GetRepositoriesParams& parameters) const override;
 	QByteArray body(const GetRepositoriesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Sets the enabled and existing package repositories.
+ */
+
+class SetRepositoriesLoader : public Jellyfin::Support::HttpLoader<void, SetRepositoriesParams> {
+public:
+	explicit SetRepositoriesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SetRepositoriesParams& parameters) const override;
+	QUrlQuery query(const SetRepositoriesParams& parameters) const override;
+	QByteArray body(const SetRepositoriesParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/playlists.h
+++ b/core/include/JellyfinQt/loader/http/playlists.h
@@ -63,6 +63,34 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Adds items to a playlist.
+ */
+
+class AddToPlaylistLoader : public Jellyfin::Support::HttpLoader<void, AddToPlaylistParams> {
+public:
+	explicit AddToPlaylistLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const AddToPlaylistParams& parameters) const override;
+	QUrlQuery query(const AddToPlaylistParams& parameters) const override;
+	QByteArray body(const AddToPlaylistParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Removes items from a playlist.
+ */
+
+class RemoveFromPlaylistLoader : public Jellyfin::Support::HttpLoader<void, RemoveFromPlaylistParams> {
+public:
+	explicit RemoveFromPlaylistLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RemoveFromPlaylistParams& parameters) const override;
+	QUrlQuery query(const RemoveFromPlaylistParams& parameters) const override;
+	QByteArray body(const RemoveFromPlaylistParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets the original items of a playlist.
  */
 
@@ -74,6 +102,20 @@ protected:
 	QString path(const GetPlaylistItemsParams& parameters) const override;
 	QUrlQuery query(const GetPlaylistItemsParams& parameters) const override;
 	QByteArray body(const GetPlaylistItemsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Moves a playlist item.
+ */
+
+class MoveItemLoader : public Jellyfin::Support::HttpLoader<void, MoveItemParams> {
+public:
+	explicit MoveItemLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const MoveItemParams& parameters) const override;
+	QUrlQuery query(const MoveItemParams& parameters) const override;
+	QByteArray body(const MoveItemParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/playstate.h
+++ b/core/include/JellyfinQt/loader/http/playstate.h
@@ -49,6 +49,62 @@ namespace HTTP {
 using namespace Jellyfin::DTO;
 
 /**
+ * @brief Reports playback has started within a session.
+ */
+
+class ReportPlaybackStartLoader : public Jellyfin::Support::HttpLoader<void, ReportPlaybackStartParams> {
+public:
+	explicit ReportPlaybackStartLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ReportPlaybackStartParams& parameters) const override;
+	QUrlQuery query(const ReportPlaybackStartParams& parameters) const override;
+	QByteArray body(const ReportPlaybackStartParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Pings a playback session.
+ */
+
+class PingPlaybackSessionLoader : public Jellyfin::Support::HttpLoader<void, PingPlaybackSessionParams> {
+public:
+	explicit PingPlaybackSessionLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PingPlaybackSessionParams& parameters) const override;
+	QUrlQuery query(const PingPlaybackSessionParams& parameters) const override;
+	QByteArray body(const PingPlaybackSessionParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports playback progress within a session.
+ */
+
+class ReportPlaybackProgressLoader : public Jellyfin::Support::HttpLoader<void, ReportPlaybackProgressParams> {
+public:
+	explicit ReportPlaybackProgressLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ReportPlaybackProgressParams& parameters) const override;
+	QUrlQuery query(const ReportPlaybackProgressParams& parameters) const override;
+	QByteArray body(const ReportPlaybackProgressParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports playback has stopped within a session.
+ */
+
+class ReportPlaybackStoppedLoader : public Jellyfin::Support::HttpLoader<void, ReportPlaybackStoppedParams> {
+public:
+	explicit ReportPlaybackStoppedLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ReportPlaybackStoppedParams& parameters) const override;
+	QUrlQuery query(const ReportPlaybackStoppedParams& parameters) const override;
+	QByteArray body(const ReportPlaybackStoppedParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Marks an item as played for user.
  */
 
@@ -74,6 +130,48 @@ protected:
 	QString path(const MarkUnplayedItemParams& parameters) const override;
 	QUrlQuery query(const MarkUnplayedItemParams& parameters) const override;
 	QByteArray body(const MarkUnplayedItemParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports that a user has begun playing an item.
+ */
+
+class OnPlaybackStartLoader : public Jellyfin::Support::HttpLoader<void, OnPlaybackStartParams> {
+public:
+	explicit OnPlaybackStartLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const OnPlaybackStartParams& parameters) const override;
+	QUrlQuery query(const OnPlaybackStartParams& parameters) const override;
+	QByteArray body(const OnPlaybackStartParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports that a user has stopped playing an item.
+ */
+
+class OnPlaybackStoppedLoader : public Jellyfin::Support::HttpLoader<void, OnPlaybackStoppedParams> {
+public:
+	explicit OnPlaybackStoppedLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const OnPlaybackStoppedParams& parameters) const override;
+	QUrlQuery query(const OnPlaybackStoppedParams& parameters) const override;
+	QByteArray body(const OnPlaybackStoppedParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports a user's playback progress.
+ */
+
+class OnPlaybackProgressLoader : public Jellyfin::Support::HttpLoader<void, OnPlaybackProgressParams> {
+public:
+	explicit OnPlaybackProgressLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const OnPlaybackProgressParams& parameters) const override;
+	QUrlQuery query(const OnPlaybackProgressParams& parameters) const override;
+	QByteArray body(const OnPlaybackProgressParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/plugins.h
+++ b/core/include/JellyfinQt/loader/http/plugins.h
@@ -63,6 +63,62 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Uninstalls a plugin.
+ */
+
+class UninstallPluginLoader : public Jellyfin::Support::HttpLoader<void, UninstallPluginParams> {
+public:
+	explicit UninstallPluginLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UninstallPluginParams& parameters) const override;
+	QUrlQuery query(const UninstallPluginParams& parameters) const override;
+	QByteArray body(const UninstallPluginParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Uninstalls a plugin by version.
+ */
+
+class UninstallPluginByVersionLoader : public Jellyfin::Support::HttpLoader<void, UninstallPluginByVersionParams> {
+public:
+	explicit UninstallPluginByVersionLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UninstallPluginByVersionParams& parameters) const override;
+	QUrlQuery query(const UninstallPluginByVersionParams& parameters) const override;
+	QByteArray body(const UninstallPluginByVersionParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Disable a plugin.
+ */
+
+class DisablePluginLoader : public Jellyfin::Support::HttpLoader<void, DisablePluginParams> {
+public:
+	explicit DisablePluginLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DisablePluginParams& parameters) const override;
+	QUrlQuery query(const DisablePluginParams& parameters) const override;
+	QByteArray body(const DisablePluginParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Enables a disabled plugin.
+ */
+
+class EnablePluginLoader : public Jellyfin::Support::HttpLoader<void, EnablePluginParams> {
+public:
+	explicit EnablePluginLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const EnablePluginParams& parameters) const override;
+	QUrlQuery query(const EnablePluginParams& parameters) const override;
+	QByteArray body(const EnablePluginParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets plugin configuration.
  */
 
@@ -74,6 +130,48 @@ protected:
 	QString path(const GetPluginConfigurationParams& parameters) const override;
 	QUrlQuery query(const GetPluginConfigurationParams& parameters) const override;
 	QByteArray body(const GetPluginConfigurationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates plugin configuration.
+ */
+
+class UpdatePluginConfigurationLoader : public Jellyfin::Support::HttpLoader<void, UpdatePluginConfigurationParams> {
+public:
+	explicit UpdatePluginConfigurationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdatePluginConfigurationParams& parameters) const override;
+	QUrlQuery query(const UpdatePluginConfigurationParams& parameters) const override;
+	QByteArray body(const UpdatePluginConfigurationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Gets a plugin's manifest.
+ */
+
+class GetPluginManifestLoader : public Jellyfin::Support::HttpLoader<void, GetPluginManifestParams> {
+public:
+	explicit GetPluginManifestLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const GetPluginManifestParams& parameters) const override;
+	QUrlQuery query(const GetPluginManifestParams& parameters) const override;
+	QByteArray body(const GetPluginManifestParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates plugin security info.
+ */
+
+class UpdatePluginSecurityInfoLoader : public Jellyfin::Support::HttpLoader<void, UpdatePluginSecurityInfoParams> {
+public:
+	explicit UpdatePluginSecurityInfoLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdatePluginSecurityInfoParams& parameters) const override;
+	QUrlQuery query(const UpdatePluginSecurityInfoParams& parameters) const override;
+	QByteArray body(const UpdatePluginSecurityInfoParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/quickconnect.h
+++ b/core/include/JellyfinQt/loader/http/quickconnect.h
@@ -50,6 +50,20 @@ namespace HTTP {
 using namespace Jellyfin::DTO;
 
 /**
+ * @brief Temporarily activates quick connect for five minutes.
+ */
+
+class ActivateLoader : public Jellyfin::Support::HttpLoader<void, ActivateParams> {
+public:
+	explicit ActivateLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ActivateParams& parameters) const override;
+	QUrlQuery query(const ActivateParams& parameters) const override;
+	QByteArray body(const ActivateParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Authorizes a pending quick connect request.
  */
 
@@ -61,6 +75,20 @@ protected:
 	QString path(const AuthorizeParams& parameters) const override;
 	QUrlQuery query(const AuthorizeParams& parameters) const override;
 	QByteArray body(const AuthorizeParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Enables or disables quick connect.
+ */
+
+class AvailableLoader : public Jellyfin::Support::HttpLoader<void, AvailableParams> {
+public:
+	explicit AvailableLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const AvailableParams& parameters) const override;
+	QUrlQuery query(const AvailableParams& parameters) const override;
+	QByteArray body(const AvailableParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**

--- a/core/include/JellyfinQt/loader/http/remoteimage.h
+++ b/core/include/JellyfinQt/loader/http/remoteimage.h
@@ -63,6 +63,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Downloads a remote image for an item.
+ */
+
+class DownloadRemoteImageLoader : public Jellyfin::Support::HttpLoader<void, DownloadRemoteImageParams> {
+public:
+	explicit DownloadRemoteImageLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DownloadRemoteImageParams& parameters) const override;
+	QUrlQuery query(const DownloadRemoteImageParams& parameters) const override;
+	QByteArray body(const DownloadRemoteImageParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets available remote image providers for an item.
  */
 

--- a/core/include/JellyfinQt/loader/http/scheduledtasks.h
+++ b/core/include/JellyfinQt/loader/http/scheduledtasks.h
@@ -76,6 +76,48 @@ protected:
 	QByteArray body(const GetTaskParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Update specified task triggers.
+ */
+
+class UpdateTaskLoader : public Jellyfin::Support::HttpLoader<void, UpdateTaskParams> {
+public:
+	explicit UpdateTaskLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateTaskParams& parameters) const override;
+	QUrlQuery query(const UpdateTaskParams& parameters) const override;
+	QByteArray body(const UpdateTaskParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Start specified task.
+ */
+
+class StartTaskLoader : public Jellyfin::Support::HttpLoader<void, StartTaskParams> {
+public:
+	explicit StartTaskLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const StartTaskParams& parameters) const override;
+	QUrlQuery query(const StartTaskParams& parameters) const override;
+	QByteArray body(const StartTaskParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Stop specified task.
+ */
+
+class StopTaskLoader : public Jellyfin::Support::HttpLoader<void, StopTaskParams> {
+public:
+	explicit StopTaskLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const StopTaskParams& parameters) const override;
+	QUrlQuery query(const StopTaskParams& parameters) const override;
+	QByteArray body(const StopTaskParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/session.h
+++ b/core/include/JellyfinQt/loader/http/session.h
@@ -91,6 +91,188 @@ protected:
 	QByteArray body(const GetSessionsParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Issues a full general command to a client.
+ */
+
+class SendFullGeneralCommandLoader : public Jellyfin::Support::HttpLoader<void, SendFullGeneralCommandParams> {
+public:
+	explicit SendFullGeneralCommandLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SendFullGeneralCommandParams& parameters) const override;
+	QUrlQuery query(const SendFullGeneralCommandParams& parameters) const override;
+	QByteArray body(const SendFullGeneralCommandParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Issues a general command to a client.
+ */
+
+class SendGeneralCommandLoader : public Jellyfin::Support::HttpLoader<void, SendGeneralCommandParams> {
+public:
+	explicit SendGeneralCommandLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SendGeneralCommandParams& parameters) const override;
+	QUrlQuery query(const SendGeneralCommandParams& parameters) const override;
+	QByteArray body(const SendGeneralCommandParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Issues a command to a client to display a message to the user.
+ */
+
+class SendMessageCommandLoader : public Jellyfin::Support::HttpLoader<void, SendMessageCommandParams> {
+public:
+	explicit SendMessageCommandLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SendMessageCommandParams& parameters) const override;
+	QUrlQuery query(const SendMessageCommandParams& parameters) const override;
+	QByteArray body(const SendMessageCommandParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Instructs a session to play an item.
+ */
+
+class PlayLoader : public Jellyfin::Support::HttpLoader<void, PlayParams> {
+public:
+	explicit PlayLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PlayParams& parameters) const override;
+	QUrlQuery query(const PlayParams& parameters) const override;
+	QByteArray body(const PlayParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Issues a playstate command to a client.
+ */
+
+class SendPlaystateCommandLoader : public Jellyfin::Support::HttpLoader<void, SendPlaystateCommandParams> {
+public:
+	explicit SendPlaystateCommandLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SendPlaystateCommandParams& parameters) const override;
+	QUrlQuery query(const SendPlaystateCommandParams& parameters) const override;
+	QByteArray body(const SendPlaystateCommandParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Issues a system command to a client.
+ */
+
+class SendSystemCommandLoader : public Jellyfin::Support::HttpLoader<void, SendSystemCommandParams> {
+public:
+	explicit SendSystemCommandLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SendSystemCommandParams& parameters) const override;
+	QUrlQuery query(const SendSystemCommandParams& parameters) const override;
+	QByteArray body(const SendSystemCommandParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Adds an additional user to a session.
+ */
+
+class AddUserToSessionLoader : public Jellyfin::Support::HttpLoader<void, AddUserToSessionParams> {
+public:
+	explicit AddUserToSessionLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const AddUserToSessionParams& parameters) const override;
+	QUrlQuery query(const AddUserToSessionParams& parameters) const override;
+	QByteArray body(const AddUserToSessionParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Removes an additional user from a session.
+ */
+
+class RemoveUserFromSessionLoader : public Jellyfin::Support::HttpLoader<void, RemoveUserFromSessionParams> {
+public:
+	explicit RemoveUserFromSessionLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RemoveUserFromSessionParams& parameters) const override;
+	QUrlQuery query(const RemoveUserFromSessionParams& parameters) const override;
+	QByteArray body(const RemoveUserFromSessionParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Instructs a session to browse to an item or view.
+ */
+
+class DisplayContentLoader : public Jellyfin::Support::HttpLoader<void, DisplayContentParams> {
+public:
+	explicit DisplayContentLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DisplayContentParams& parameters) const override;
+	QUrlQuery query(const DisplayContentParams& parameters) const override;
+	QByteArray body(const DisplayContentParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates capabilities for a device.
+ */
+
+class PostCapabilitiesLoader : public Jellyfin::Support::HttpLoader<void, PostCapabilitiesParams> {
+public:
+	explicit PostCapabilitiesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostCapabilitiesParams& parameters) const override;
+	QUrlQuery query(const PostCapabilitiesParams& parameters) const override;
+	QByteArray body(const PostCapabilitiesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates capabilities for a device.
+ */
+
+class PostFullCapabilitiesLoader : public Jellyfin::Support::HttpLoader<void, PostFullCapabilitiesParams> {
+public:
+	explicit PostFullCapabilitiesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const PostFullCapabilitiesParams& parameters) const override;
+	QUrlQuery query(const PostFullCapabilitiesParams& parameters) const override;
+	QByteArray body(const PostFullCapabilitiesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports that a session has ended.
+ */
+
+class ReportSessionEndedLoader : public Jellyfin::Support::HttpLoader<void, ReportSessionEndedParams> {
+public:
+	explicit ReportSessionEndedLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ReportSessionEndedParams& parameters) const override;
+	QUrlQuery query(const ReportSessionEndedParams& parameters) const override;
+	QByteArray body(const ReportSessionEndedParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Reports that a session is viewing an item.
+ */
+
+class ReportViewingLoader : public Jellyfin::Support::HttpLoader<void, ReportViewingParams> {
+public:
+	explicit ReportViewingLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ReportViewingParams& parameters) const override;
+	QUrlQuery query(const ReportViewingParams& parameters) const override;
+	QByteArray body(const ReportViewingParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/startup.h
+++ b/core/include/JellyfinQt/loader/http/startup.h
@@ -50,6 +50,20 @@ namespace HTTP {
 using namespace Jellyfin::DTO;
 
 /**
+ * @brief Completes the startup wizard.
+ */
+
+class CompleteWizardLoader : public Jellyfin::Support::HttpLoader<void, CompleteWizardParams> {
+public:
+	explicit CompleteWizardLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const CompleteWizardParams& parameters) const override;
+	QUrlQuery query(const CompleteWizardParams& parameters) const override;
+	QByteArray body(const CompleteWizardParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets the initial startup wizard configuration.
  */
 
@@ -61,6 +75,20 @@ protected:
 	QString path(const GetStartupConfigurationParams& parameters) const override;
 	QUrlQuery query(const GetStartupConfigurationParams& parameters) const override;
 	QByteArray body(const GetStartupConfigurationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Sets the initial startup wizard configuration.
+ */
+
+class UpdateInitialConfigurationLoader : public Jellyfin::Support::HttpLoader<void, UpdateInitialConfigurationParams> {
+public:
+	explicit UpdateInitialConfigurationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateInitialConfigurationParams& parameters) const override;
+	QUrlQuery query(const UpdateInitialConfigurationParams& parameters) const override;
+	QByteArray body(const UpdateInitialConfigurationParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
@@ -78,6 +106,20 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Sets remote access and UPnP.
+ */
+
+class SetRemoteAccessLoader : public Jellyfin::Support::HttpLoader<void, SetRemoteAccessParams> {
+public:
+	explicit SetRemoteAccessLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SetRemoteAccessParams& parameters) const override;
+	QUrlQuery query(const SetRemoteAccessParams& parameters) const override;
+	QByteArray body(const SetRemoteAccessParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets the first user.
  */
 
@@ -89,6 +131,20 @@ protected:
 	QString path(const GetFirstUserParams& parameters) const override;
 	QUrlQuery query(const GetFirstUserParams& parameters) const override;
 	QByteArray body(const GetFirstUserParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Sets the user name and password.
+ */
+
+class UpdateStartupUserLoader : public Jellyfin::Support::HttpLoader<void, UpdateStartupUserParams> {
+public:
+	explicit UpdateStartupUserLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateStartupUserParams& parameters) const override;
+	QUrlQuery query(const UpdateStartupUserParams& parameters) const override;
+	QByteArray body(const UpdateStartupUserParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/subtitle.h
+++ b/core/include/JellyfinQt/loader/http/subtitle.h
@@ -76,6 +76,48 @@ protected:
 	QByteArray body(const SearchRemoteSubtitlesParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Downloads a remote subtitle.
+ */
+
+class DownloadRemoteSubtitlesLoader : public Jellyfin::Support::HttpLoader<void, DownloadRemoteSubtitlesParams> {
+public:
+	explicit DownloadRemoteSubtitlesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DownloadRemoteSubtitlesParams& parameters) const override;
+	QUrlQuery query(const DownloadRemoteSubtitlesParams& parameters) const override;
+	QByteArray body(const DownloadRemoteSubtitlesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Upload an external subtitle file.
+ */
+
+class UploadSubtitleLoader : public Jellyfin::Support::HttpLoader<void, UploadSubtitleParams> {
+public:
+	explicit UploadSubtitleLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UploadSubtitleParams& parameters) const override;
+	QUrlQuery query(const UploadSubtitleParams& parameters) const override;
+	QByteArray body(const UploadSubtitleParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Deletes an external subtitle file.
+ */
+
+class DeleteSubtitleLoader : public Jellyfin::Support::HttpLoader<void, DeleteSubtitleParams> {
+public:
+	explicit DeleteSubtitleLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteSubtitleParams& parameters) const override;
+	QUrlQuery query(const DeleteSubtitleParams& parameters) const override;
+	QByteArray body(const DeleteSubtitleParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/http/syncplay.h
+++ b/core/include/JellyfinQt/loader/http/syncplay.h
@@ -48,6 +48,48 @@ namespace HTTP {
 using namespace Jellyfin::DTO;
 
 /**
+ * @brief Notify SyncPlay group that member is buffering.
+ */
+
+class SyncPlayBufferingLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayBufferingParams> {
+public:
+	explicit SyncPlayBufferingLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayBufferingParams& parameters) const override;
+	QUrlQuery query(const SyncPlayBufferingParams& parameters) const override;
+	QByteArray body(const SyncPlayBufferingParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Join an existing SyncPlay group.
+ */
+
+class SyncPlayJoinGroupLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayJoinGroupParams> {
+public:
+	explicit SyncPlayJoinGroupLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayJoinGroupParams& parameters) const override;
+	QUrlQuery query(const SyncPlayJoinGroupParams& parameters) const override;
+	QByteArray body(const SyncPlayJoinGroupParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Leave the joined SyncPlay group.
+ */
+
+class SyncPlayLeaveGroupLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayLeaveGroupParams> {
+public:
+	explicit SyncPlayLeaveGroupLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayLeaveGroupParams& parameters) const override;
+	QUrlQuery query(const SyncPlayLeaveGroupParams& parameters) const override;
+	QByteArray body(const SyncPlayLeaveGroupParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets all SyncPlay groups.
  */
 
@@ -59,6 +101,244 @@ protected:
 	QString path(const SyncPlayGetGroupsParams& parameters) const override;
 	QUrlQuery query(const SyncPlayGetGroupsParams& parameters) const override;
 	QByteArray body(const SyncPlayGetGroupsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request to move an item in the playlist in SyncPlay group.
+ */
+
+class SyncPlayMovePlaylistItemLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayMovePlaylistItemParams> {
+public:
+	explicit SyncPlayMovePlaylistItemLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayMovePlaylistItemParams& parameters) const override;
+	QUrlQuery query(const SyncPlayMovePlaylistItemParams& parameters) const override;
+	QByteArray body(const SyncPlayMovePlaylistItemParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Create a new SyncPlay group.
+ */
+
+class SyncPlayCreateGroupLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayCreateGroupParams> {
+public:
+	explicit SyncPlayCreateGroupLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayCreateGroupParams& parameters) const override;
+	QUrlQuery query(const SyncPlayCreateGroupParams& parameters) const override;
+	QByteArray body(const SyncPlayCreateGroupParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request next item in SyncPlay group.
+ */
+
+class SyncPlayNextItemLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayNextItemParams> {
+public:
+	explicit SyncPlayNextItemLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayNextItemParams& parameters) const override;
+	QUrlQuery query(const SyncPlayNextItemParams& parameters) const override;
+	QByteArray body(const SyncPlayNextItemParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request pause in SyncPlay group.
+ */
+
+class SyncPlayPauseLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayPauseParams> {
+public:
+	explicit SyncPlayPauseLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayPauseParams& parameters) const override;
+	QUrlQuery query(const SyncPlayPauseParams& parameters) const override;
+	QByteArray body(const SyncPlayPauseParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Update session ping.
+ */
+
+class SyncPlayPingLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayPingParams> {
+public:
+	explicit SyncPlayPingLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayPingParams& parameters) const override;
+	QUrlQuery query(const SyncPlayPingParams& parameters) const override;
+	QByteArray body(const SyncPlayPingParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request previous item in SyncPlay group.
+ */
+
+class SyncPlayPreviousItemLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayPreviousItemParams> {
+public:
+	explicit SyncPlayPreviousItemLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayPreviousItemParams& parameters) const override;
+	QUrlQuery query(const SyncPlayPreviousItemParams& parameters) const override;
+	QByteArray body(const SyncPlayPreviousItemParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request to queue items to the playlist of a SyncPlay group.
+ */
+
+class SyncPlayQueueLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayQueueParams> {
+public:
+	explicit SyncPlayQueueLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayQueueParams& parameters) const override;
+	QUrlQuery query(const SyncPlayQueueParams& parameters) const override;
+	QByteArray body(const SyncPlayQueueParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Notify SyncPlay group that member is ready for playback.
+ */
+
+class SyncPlayReadyLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayReadyParams> {
+public:
+	explicit SyncPlayReadyLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayReadyParams& parameters) const override;
+	QUrlQuery query(const SyncPlayReadyParams& parameters) const override;
+	QByteArray body(const SyncPlayReadyParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request to remove items from the playlist in SyncPlay group.
+ */
+
+class SyncPlayRemoveFromPlaylistLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayRemoveFromPlaylistParams> {
+public:
+	explicit SyncPlayRemoveFromPlaylistLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayRemoveFromPlaylistParams& parameters) const override;
+	QUrlQuery query(const SyncPlayRemoveFromPlaylistParams& parameters) const override;
+	QByteArray body(const SyncPlayRemoveFromPlaylistParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request seek in SyncPlay group.
+ */
+
+class SyncPlaySeekLoader : public Jellyfin::Support::HttpLoader<void, SyncPlaySeekParams> {
+public:
+	explicit SyncPlaySeekLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlaySeekParams& parameters) const override;
+	QUrlQuery query(const SyncPlaySeekParams& parameters) const override;
+	QByteArray body(const SyncPlaySeekParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request SyncPlay group to ignore member during group-wait.
+ */
+
+class SyncPlaySetIgnoreWaitLoader : public Jellyfin::Support::HttpLoader<void, SyncPlaySetIgnoreWaitParams> {
+public:
+	explicit SyncPlaySetIgnoreWaitLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlaySetIgnoreWaitParams& parameters) const override;
+	QUrlQuery query(const SyncPlaySetIgnoreWaitParams& parameters) const override;
+	QByteArray body(const SyncPlaySetIgnoreWaitParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request to set new playlist in SyncPlay group.
+ */
+
+class SyncPlaySetNewQueueLoader : public Jellyfin::Support::HttpLoader<void, SyncPlaySetNewQueueParams> {
+public:
+	explicit SyncPlaySetNewQueueLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlaySetNewQueueParams& parameters) const override;
+	QUrlQuery query(const SyncPlaySetNewQueueParams& parameters) const override;
+	QByteArray body(const SyncPlaySetNewQueueParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request to change playlist item in SyncPlay group.
+ */
+
+class SyncPlaySetPlaylistItemLoader : public Jellyfin::Support::HttpLoader<void, SyncPlaySetPlaylistItemParams> {
+public:
+	explicit SyncPlaySetPlaylistItemLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlaySetPlaylistItemParams& parameters) const override;
+	QUrlQuery query(const SyncPlaySetPlaylistItemParams& parameters) const override;
+	QByteArray body(const SyncPlaySetPlaylistItemParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request to set repeat mode in SyncPlay group.
+ */
+
+class SyncPlaySetRepeatModeLoader : public Jellyfin::Support::HttpLoader<void, SyncPlaySetRepeatModeParams> {
+public:
+	explicit SyncPlaySetRepeatModeLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlaySetRepeatModeParams& parameters) const override;
+	QUrlQuery query(const SyncPlaySetRepeatModeParams& parameters) const override;
+	QByteArray body(const SyncPlaySetRepeatModeParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request to set shuffle mode in SyncPlay group.
+ */
+
+class SyncPlaySetShuffleModeLoader : public Jellyfin::Support::HttpLoader<void, SyncPlaySetShuffleModeParams> {
+public:
+	explicit SyncPlaySetShuffleModeLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlaySetShuffleModeParams& parameters) const override;
+	QUrlQuery query(const SyncPlaySetShuffleModeParams& parameters) const override;
+	QByteArray body(const SyncPlaySetShuffleModeParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request stop in SyncPlay group.
+ */
+
+class SyncPlayStopLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayStopParams> {
+public:
+	explicit SyncPlayStopLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayStopParams& parameters) const override;
+	QUrlQuery query(const SyncPlayStopParams& parameters) const override;
+	QByteArray body(const SyncPlayStopParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Request unpause in SyncPlay group.
+ */
+
+class SyncPlayUnpauseLoader : public Jellyfin::Support::HttpLoader<void, SyncPlayUnpauseParams> {
+public:
+	explicit SyncPlayUnpauseLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const SyncPlayUnpauseParams& parameters) const override;
+	QUrlQuery query(const SyncPlayUnpauseParams& parameters) const override;
+	QByteArray body(const SyncPlayUnpauseParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 

--- a/core/include/JellyfinQt/loader/http/system.h
+++ b/core/include/JellyfinQt/loader/http/system.h
@@ -136,6 +136,34 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Restarts the application.
+ */
+
+class RestartApplicationLoader : public Jellyfin::Support::HttpLoader<void, RestartApplicationParams> {
+public:
+	explicit RestartApplicationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const RestartApplicationParams& parameters) const override;
+	QUrlQuery query(const RestartApplicationParams& parameters) const override;
+	QByteArray body(const RestartApplicationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Shuts down the application.
+ */
+
+class ShutdownApplicationLoader : public Jellyfin::Support::HttpLoader<void, ShutdownApplicationParams> {
+public:
+	explicit ShutdownApplicationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const ShutdownApplicationParams& parameters) const override;
+	QUrlQuery query(const ShutdownApplicationParams& parameters) const override;
+	QByteArray body(const ShutdownApplicationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Gets wake on lan information.
  */
 

--- a/core/include/JellyfinQt/loader/http/user.h
+++ b/core/include/JellyfinQt/loader/http/user.h
@@ -85,6 +85,34 @@ protected:
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**
+ * @brief Deletes a user.
+ */
+
+class DeleteUserLoader : public Jellyfin::Support::HttpLoader<void, DeleteUserParams> {
+public:
+	explicit DeleteUserLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteUserParams& parameters) const override;
+	QUrlQuery query(const DeleteUserParams& parameters) const override;
+	QByteArray body(const DeleteUserParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a user.
+ */
+
+class UpdateUserLoader : public Jellyfin::Support::HttpLoader<void, UpdateUserParams> {
+public:
+	explicit UpdateUserLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateUserParams& parameters) const override;
+	QUrlQuery query(const UpdateUserParams& parameters) const override;
+	QByteArray body(const UpdateUserParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
  * @brief Authenticates a user.
  */
 
@@ -96,6 +124,62 @@ protected:
 	QString path(const AuthenticateUserParams& parameters) const override;
 	QUrlQuery query(const AuthenticateUserParams& parameters) const override;
 	QByteArray body(const AuthenticateUserParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a user configuration.
+ */
+
+class UpdateUserConfigurationLoader : public Jellyfin::Support::HttpLoader<void, UpdateUserConfigurationParams> {
+public:
+	explicit UpdateUserConfigurationLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateUserConfigurationParams& parameters) const override;
+	QUrlQuery query(const UpdateUserConfigurationParams& parameters) const override;
+	QByteArray body(const UpdateUserConfigurationParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a user's easy password.
+ */
+
+class UpdateUserEasyPasswordLoader : public Jellyfin::Support::HttpLoader<void, UpdateUserEasyPasswordParams> {
+public:
+	explicit UpdateUserEasyPasswordLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateUserEasyPasswordParams& parameters) const override;
+	QUrlQuery query(const UpdateUserEasyPasswordParams& parameters) const override;
+	QByteArray body(const UpdateUserEasyPasswordParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a user's password.
+ */
+
+class UpdateUserPasswordLoader : public Jellyfin::Support::HttpLoader<void, UpdateUserPasswordParams> {
+public:
+	explicit UpdateUserPasswordLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateUserPasswordParams& parameters) const override;
+	QUrlQuery query(const UpdateUserPasswordParams& parameters) const override;
+	QByteArray body(const UpdateUserPasswordParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Updates a user policy.
+ */
+
+class UpdateUserPolicyLoader : public Jellyfin::Support::HttpLoader<void, UpdateUserPolicyParams> {
+public:
+	explicit UpdateUserPolicyLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const UpdateUserPolicyParams& parameters) const override;
+	QUrlQuery query(const UpdateUserPolicyParams& parameters) const override;
+	QByteArray body(const UpdateUserPolicyParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
 /**

--- a/core/include/JellyfinQt/loader/http/videos.h
+++ b/core/include/JellyfinQt/loader/http/videos.h
@@ -61,6 +61,34 @@ protected:
 	QByteArray body(const GetAdditionalPartParams& parameters) const override;
 	QNetworkAccessManager::Operation operation() const override;
 };
+/**
+ * @brief Removes alternate video sources.
+ */
+
+class DeleteAlternateSourcesLoader : public Jellyfin::Support::HttpLoader<void, DeleteAlternateSourcesParams> {
+public:
+	explicit DeleteAlternateSourcesLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const DeleteAlternateSourcesParams& parameters) const override;
+	QUrlQuery query(const DeleteAlternateSourcesParams& parameters) const override;
+	QByteArray body(const DeleteAlternateSourcesParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
+/**
+ * @brief Merges videos into a single record.
+ */
+
+class MergeVersionsLoader : public Jellyfin::Support::HttpLoader<void, MergeVersionsParams> {
+public:
+	explicit MergeVersionsLoader(ApiClient *apiClient = nullptr);
+
+protected:
+	QString path(const MergeVersionsParams& parameters) const override;
+	QUrlQuery query(const MergeVersionsParams& parameters) const override;
+	QByteArray body(const MergeVersionsParams& parameters) const override;
+	QNetworkAccessManager::Operation operation() const override;
+};
 
 } // NS HTTP
 } // NS Loader

--- a/core/include/JellyfinQt/loader/requesttypes.h
+++ b/core/include/JellyfinQt/loader/requesttypes.h
@@ -27729,12 +27729,48 @@ public:
 
 	
 	/**
+	 * @brief Optional. The index of the audio stream to play.	
+	 */
+	const qint32 &audioStreamIndex() const;
+	void setAudioStreamIndex(qint32 newAudioStreamIndex);
+	bool audioStreamIndexNull() const;
+	void setAudioStreamIndexNull();
+	
+	
+	/**
+	 * @brief Optional. The media source id.	
+	 */
+	const QString &mediaSourceId() const;
+	void setMediaSourceId(QString newMediaSourceId);
+	bool mediaSourceIdNull() const;
+	void setMediaSourceIdNull();
+	
+	
+	/**
+	 * @brief Optional. The start index.	
+	 */
+	const qint32 &startIndex() const;
+	void setStartIndex(qint32 newStartIndex);
+	bool startIndexNull() const;
+	void setStartIndexNull();
+	
+	
+	/**
 	 * @brief The starting position of the first item.	
 	 */
 	const qint64 &startPositionTicks() const;
 	void setStartPositionTicks(qint64 newStartPositionTicks);
 	bool startPositionTicksNull() const;
 	void setStartPositionTicksNull();
+	
+	
+	/**
+	 * @brief Optional. The index of the subtitle stream to play.	
+	 */
+	const qint32 &subtitleStreamIndex() const;
+	void setSubtitleStreamIndex(qint32 newSubtitleStreamIndex);
+	bool subtitleStreamIndexNull() const;
+	void setSubtitleStreamIndexNull();
 	
 	
 private:
@@ -27746,7 +27782,11 @@ private:
 	PlayCommand m_playCommand;
 
 	// Optional query parameters
+	std::optional<qint32> m_audioStreamIndex = std::nullopt;
+	QString m_mediaSourceId;
+	std::optional<qint32> m_startIndex = std::nullopt;
 	std::optional<qint64> m_startPositionTicks = std::nullopt;
+	std::optional<qint32> m_subtitleStreamIndex = std::nullopt;
 
 
 };

--- a/core/include/JellyfinQt/model/controllablesession.h
+++ b/core/include/JellyfinQt/model/controllablesession.h
@@ -105,7 +105,7 @@ private:
 class ControllableJellyfinSession : public ControllableSession {
     Q_OBJECT
 public:
-    ControllableJellyfinSession(QSharedPointer<DTO::SessionInfo> info, QObject *parent = nullptr);
+    ControllableJellyfinSession(QSharedPointer<DTO::SessionInfo> info, ApiClient &apiClient, QObject *parent = nullptr);
     QString id() const override;
     QString name() const override;
     QString appName() const override;
@@ -114,6 +114,7 @@ public:
     PlaybackManager *createPlaybackManager() const override;
 private:
     QSharedPointer<DTO::SessionInfo> m_data;
+    ApiClient &m_apiClient;
 };
 
 /**

--- a/core/include/JellyfinQt/model/controllablesession.h
+++ b/core/include/JellyfinQt/model/controllablesession.h
@@ -1,0 +1,171 @@
+#ifndef JELLYFIN_MODEL_CONTROLLABLESESSION_H
+#define JELLYFIN_MODEL_CONTROLLABLESESSION_H
+
+#include <QObject>
+#include <QScopedPointer>
+#include <QSharedPointer>
+
+#include "JellyfinQt/dto/sessioninfo.h"
+
+namespace Jellyfin {
+
+class ApiClient;
+
+namespace DTO {
+class ClientCapabilities;
+} // NS DTO
+
+namespace Model {
+
+class PlaybackManager;
+
+class DeviceTypeClass { Q_GADGET
+public:
+    enum Value {
+        Unknown,
+        Tv,
+        Computer,
+        Phone
+    };
+    Q_ENUM(Value)
+};
+
+class MediaTypeClass {
+    Q_GADGET
+public:
+    enum Value {
+        None  = 0x0,
+        Audio = 0x1,
+        Video = 0x2,
+        Photo = 0x4
+    };
+    Q_DECLARE_FLAGS(MediaTypes, Value)
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(MediaTypeClass::MediaTypes)
+
+using DeviceType = DeviceTypeClass::Value;
+using MediaTypes = MediaTypeClass::MediaTypes;
+
+/**
+ * @brief Abstract class for describing a playback session that can be controlled.
+ *
+ * Main purpose for this class is to hold information for displaying it in a UI for an user to select
+ * and to create an implementation of a PlaybackManager instance to control this session.
+ */
+class ControllableSession : public QObject {
+    Q_OBJECT
+public:
+    explicit ControllableSession(QObject *parent = nullptr);
+    /**
+     * @brief An unique id for this session.
+     */
+    virtual QString id() const = 0;
+    /**
+     * @brief An human-readable name for this session
+     */
+    virtual QString name() const = 0;
+    /**
+     * @brief The app for this session
+     */
+    virtual QString appName() const = 0;
+    virtual DeviceType deviceType() const = 0;
+
+    /**
+     * @brief user The username of who started this session
+     */
+    virtual QString userName() const = 0;
+    /**
+     * @brief Creates a playbackManager for this device. This PlaybackManager has no
+     * QObject parent and must be cleaned up by the caller.
+     */
+    virtual PlaybackManager *createPlaybackManager() const = 0;
+};
+
+/**
+ * @brief Dummy session representing this device.
+ */
+class LocalSession : public ControllableSession {
+    Q_OBJECT
+public:
+    LocalSession(ApiClient &apiClient, QObject *parent = nullptr);
+    QString id() const override;
+    QString name() const override;
+    QString appName() const override;
+    DeviceType deviceType() const override;
+    QString userName() const override;
+    PlaybackManager *createPlaybackManager() const override;
+private:
+    ApiClient &m_apiClient;
+};
+
+/**
+ * @brief A session on the Jellyfin server that can be controlled.
+ */
+class ControllableJellyfinSession : public ControllableSession {
+    Q_OBJECT
+public:
+    ControllableJellyfinSession(QSharedPointer<DTO::SessionInfo> info, QObject *parent = nullptr);
+    QString id() const override;
+    QString name() const override;
+    QString appName() const override;
+    DeviceType deviceType() const override;
+    QString userName() const override;
+    PlaybackManager *createPlaybackManager() const override;
+private:
+    QSharedPointer<DTO::SessionInfo> m_data;
+};
+
+/**
+ * Abstract class for finding remotely controllable sessions
+ */
+class RemoteSessionScanner : public QObject {
+    Q_OBJECT
+public:
+    explicit RemoteSessionScanner(QObject *parent = nullptr);
+    /**
+     * The session scanner should start discovering sessions
+     */
+    virtual void startScanning() = 0;
+    /**
+     * The session scanner should stop discovering sessions
+     */
+    virtual void stopScanning() = 0;
+signals:
+    /**
+     * This signal should be emitted when an session has been discovered.
+     * The session should be reparented to whoever is listening for this signal.
+     */
+    void sessionFound(Jellyfin::Model::ControllableSession *session);
+    /**
+     * Should be emitted when an session is gone.
+     */
+    void sessionLost(const QString &sessionId);
+    /**
+     * Should be emitted when the listener should delete all sessions by this discoverer.
+     */
+    void resetSessions();
+};
+
+
+class RemoteJellyfinSessionScannerPrivate;
+/**
+ * @brief Lists controllable Jellyfin sessions from the Jellyfin server
+ */
+class RemoteJellyfinSessionScanner : public RemoteSessionScanner {
+    Q_OBJECT
+    Q_DECLARE_PRIVATE(RemoteJellyfinSessionScanner);
+public:
+    explicit RemoteJellyfinSessionScanner(ApiClient *client, QObject *parent);
+    virtual ~RemoteJellyfinSessionScanner();
+
+    void startScanning() override;
+    void stopScanning() override;
+private:
+    QScopedPointer<RemoteJellyfinSessionScannerPrivate> d_ptr;
+};
+
+} // NS Model
+} // NS Jellyfin
+
+#endif // JELLYFIN_MODEL_CONTROLLABLESESSION_H

--- a/core/include/JellyfinQt/model/playbackmanager.h
+++ b/core/include/JellyfinQt/model/playbackmanager.h
@@ -84,12 +84,11 @@ class PlaybackManager : public QObject {
     Q_PROPERTY(bool hasVideo READ hasVideo NOTIFY hasVideoChanged)
     Q_PROPERTY(Jellyfin::Model::PlayerStateClass::Value playbackState READ playbackState NOTIFY playbackStateChanged)
     Q_PROPERTY(Jellyfin::Model::MediaStatusClass::Value mediaStatus READ mediaStatus NOTIFY mediaStatusChanged)
-    Q_PROPERTY(Jellyfin::Model::Playlist *queue READ queue NOTIFY queueChanged)
     Q_PROPERTY(int queueIndex READ queueIndex NOTIFY queueIndexChanged)
 public:
     explicit PlaybackManager(QObject *parent = nullptr);
     virtual ~PlaybackManager();
-    virtual void swap(PlaybackManager& other) = 0;
+    void swap(PlaybackManager& other);
 
     ApiClient * apiClient() const;
     void setApiClient(ApiClient *apiClient);
@@ -129,6 +128,9 @@ public:
      * @param index Index of the item to play
      */
     virtual void playItemInList(const QList<QSharedPointer<Model::Item>> &items, int index) = 0;
+    static const qint64 MS_TICK_FACTOR = 10000;
+protected:
+    void setItem(QSharedPointer<Item> item);
 
 signals:
     void playbackStateChanged(Jellyfin::Model::PlayerStateClass::Value newPlaybackState);
@@ -189,8 +191,6 @@ class LocalPlaybackManager : public PlaybackManager {
     Q_PROPERTY(QUrl streamUrl READ streamUrl NOTIFY streamUrlChanged)
 public:
     explicit LocalPlaybackManager(QObject *parent = nullptr);
-
-    void swap(PlaybackManager& other) override;
 
     Player *player() const;
     QString sessionId() const;

--- a/core/include/JellyfinQt/model/playbackmanager.h
+++ b/core/include/JellyfinQt/model/playbackmanager.h
@@ -131,6 +131,7 @@ public:
     static const qint64 MS_TICK_FACTOR = 10000;
 protected:
     void setItem(QSharedPointer<Item> item);
+    void setQueueIndex(int index);
 
 signals:
     void playbackStateChanged(Jellyfin::Model::PlayerStateClass::Value newPlaybackState);

--- a/core/include/JellyfinQt/model/playbackmanager.h
+++ b/core/include/JellyfinQt/model/playbackmanager.h
@@ -62,10 +62,25 @@ class PlaybackManager : public QObject {
     Q_PROPERTY(bool resumePlayback READ resumePlayback WRITE setResumePlayback NOTIFY resumePlaybackChanged)
     Q_PROPERTY(int audioIndex READ audioIndex WRITE setAudioIndex NOTIFY audioIndexChanged)
     Q_PROPERTY(int subtitleIndex READ subtitleIndex WRITE setSubtitleIndex NOTIFY subtitleIndexChanged)
+    /**
+     * @brief The position in ticks in the currently playing item
+     */
     Q_PROPERTY(qint64 position READ position NOTIFY positionChanged)
+    /**
+     * @brief The duration in ticks of the currently playing item
+     */
     Q_PROPERTY(qint64 duration READ duration NOTIFY durationChanged)
+    /**
+     * @brief Whether the playbackmanager is currently able to seek
+     */
     Q_PROPERTY(bool seekable READ seekable NOTIFY seekableChanged)
+    /**
+     * @brief Whether the currently playing item has audio
+     */
     Q_PROPERTY(bool hasAudio READ hasAudio NOTIFY hasAudioChanged)
+    /**
+     * @brief Whether the currently playing item has video
+     */
     Q_PROPERTY(bool hasVideo READ hasVideo NOTIFY hasVideoChanged)
     Q_PROPERTY(Jellyfin::Model::PlayerStateClass::Value playbackState READ playbackState NOTIFY playbackStateChanged)
     Q_PROPERTY(Jellyfin::Model::MediaStatusClass::Value mediaStatus READ mediaStatus NOTIFY mediaStatusChanged)
@@ -104,7 +119,15 @@ public:
     virtual bool hasAudio() const = 0;
     virtual bool hasVideo() const = 0;
 
+    /**
+     * @brief Start playing the given item
+     */
     virtual void playItem(QSharedPointer<Model::Item> item) = 0;
+    /**
+     * @brief Set the playlist to the given playlist and start playing the item at the given index
+     * @param items The list of items to play
+     * @param index Index of the item to play
+     */
     virtual void playItemInList(const QList<QSharedPointer<Model::Item>> &items, int index) = 0;
 
 signals:

--- a/core/include/JellyfinQt/model/playlist.h
+++ b/core/include/JellyfinQt/model/playlist.h
@@ -72,6 +72,11 @@ public:
      */
     void next();
 
+    /**
+     * @brief Returns all items in the queue
+     */
+    QList<QSharedPointer<Item>> queueAndList() const;
+
     int queueSize() { return m_queue.size(); };
     int listSize() const { return m_list.size(); };
     int totalSize() const { return m_queue.size() + m_list.size(); }

--- a/core/include/JellyfinQt/model/remotejellyfinplayback.h
+++ b/core/include/JellyfinQt/model/remotejellyfinplayback.h
@@ -1,0 +1,74 @@
+/*
+ * Sailfin: a Jellyfin client written using Qt
+ * Copyright (C) 2023 Chris Josten and the Sailfin Contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef JELLYFIN_MODEL_REMOTEJELLYFINPLAYBACK_H
+#define JELLYFIN_MODEL_REMOTEJELLYFINPLAYBACK_H
+
+#include <JellyfinQt/dto/generalcommandtype.h>
+#include <JellyfinQt/model/playbackmanager.h>
+
+#include <QJsonObject>
+#include <QSharedPointer>
+
+namespace Jellyfin {
+
+class ApiClient;
+
+namespace Model {
+
+class RemoteJellyfinPlayback : public PlaybackManager {
+public:
+    RemoteJellyfinPlayback(ApiClient &apiClient, QObject *parent = nullptr);
+
+
+    // PlaybackManager
+    void swap(PlaybackManager &other) override;
+    PlayerState playbackState() const override;
+    MediaStatus mediaStatus() const override;
+    bool hasNext() const override;
+    bool hasPrevious() const override;
+    PlaybackManagerError error() const override;
+    const QString &errorString() const override;
+    qint64 position() const override;
+    qint64 duration() const override;
+    bool seekable() const override;
+    bool hasAudio() const override;
+    bool hasVideo() const override;
+    void playItem(QSharedPointer<Item> item) override;
+    void playItemInList(const QList<QSharedPointer<Item> > &items, int index) override;
+
+public slots:
+    void pause() override;
+    void play() override;
+    void playItemId(const QString &id) override;
+    void previous() override;
+    void next() override;
+    void goTo(int index) override;
+    void stop() override;
+    void seek(qint64 pos) override;
+private:
+    void sendGeneralCommand(DTO::GeneralCommandType command, QJsonObject arguments = QJsonObject());
+    ApiClient &m_apiClient;
+};
+
+
+} // NS Model
+} // NS Jellyfin
+
+
+#endif // JELLYFIN_MODEL_REMOTEJELLYFINPLAYBACK_H

--- a/core/include/JellyfinQt/model/remotejellyfinplayback.h
+++ b/core/include/JellyfinQt/model/remotejellyfinplayback.h
@@ -75,6 +75,17 @@ private:
     void sendGeneralCommand(DTO::GeneralCommandType command, QJsonObject arguments = QJsonObject());
     void sendCommand(Support::LoaderBase *loader);
     void playItemInList(const QStringList &items, int index, qint64 resumeTicks = -1);
+    /**
+     * @brief isQueueSame Checks if the items in the list are the same as in the queue
+     * @param items The item ids to compare to the queue
+     * @return True if the same, otherwise false
+     */
+    bool isQueueSame(QList<QueueItem> itemIds);
+    /**
+     * Updates the now playing queue, with the given items
+     * @param itemIds The item ids to load
+     */
+    void updateQueue(QList<QueueItem> itemIds);
     ApiClient &m_apiClient;
     QString m_sessionId;
     std::optional<DTO::SessionInfo> m_lastSessionInfo;

--- a/core/include/JellyfinQt/support/jsonconvimpl.h
+++ b/core/include/JellyfinQt/support/jsonconvimpl.h
@@ -155,6 +155,8 @@ QString toString(const T &source, convertType<T>) {
         return QJsonDocument(val.toArray()).toJson(format);
     case QJsonValue::Object:
         return QJsonDocument(val.toObject()).toJson(format);
+    case QJsonValue::String:
+        return val.toString();
     case QJsonValue::Null:
     default:
         return QString();

--- a/core/include/JellyfinQt/support/loader.h
+++ b/core/include/JellyfinQt/support/loader.h
@@ -334,9 +334,6 @@ private:
         int statusCode = m_reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
         m_reply->deleteLater();
         m_reply = nullptr;
-        /*m_parsedWatcher.setFuture(QtConcurrent::run([this, statusCode, array]() {
-            return this->parseResponse(statusCode, array);
-        }));*/
         m_parsedWatcher.setFuture(
                     QtConcurrent::run<typename HttpLoader<R, P>::ResultType, // Result
                                       HttpLoader<R, P>,                      // class

--- a/core/include/JellyfinQt/viewmodel/playbackmanager.h
+++ b/core/include/JellyfinQt/viewmodel/playbackmanager.h
@@ -20,11 +20,12 @@
 #define JELLYFIN_VIEWMODEL_PLAYBACKMANAGER_H
 
 #include <QAbstractItemModel>
+#include <QFuture>
 #include <QJsonArray>
 #include <QJsonObject>
 #include <QLoggingCategory>
-#include <QFuture>
 #include <QObject>
+#include <QSharedPointer>
 #include <QtGlobal>
 #include <QUrlQuery>
 #include <QVariant>
@@ -34,17 +35,18 @@
 
 #include <functional>
 
-#include "../dto/baseitemdto.h"
-#include "../dto/playbackinfodto.h"
-#include "../dto/playbackinforesponse.h"
-#include "../dto/playmethod.h"
-#include "../loader/requesttypes.h"
-#include "../model/player.h"
-#include "../model/playlist.h"
-#include "../support/jsonconv.h"
-#include "../viewmodel/item.h"
-#include "../viewmodel/playlist.h"
-#include "../apiclient.h"
+#include <JellyfinQt/dto/baseitemdto.h>
+#include <JellyfinQt/dto/playbackinfodto.h>
+#include <JellyfinQt/dto/playbackinforesponse.h>
+#include <JellyfinQt/dto/playmethod.h>
+#include <JellyfinQt/loader/requesttypes.h>
+#include <JellyfinQt/model/controllablesession.h>
+#include <JellyfinQt/model/player.h>
+#include <JellyfinQt/model/playlist.h>
+#include <JellyfinQt/support/jsonconv.h>
+#include <JellyfinQt/viewmodel/item.h>
+#include <JellyfinQt/viewmodel/playlist.h>
+#include <JellyfinQt/apiclient.h>
 #include "itemmodel.h"
 
 
@@ -81,6 +83,13 @@ public:
     virtual ~PlaybackManager();
 
     Q_PROPERTY(ApiClient *apiClient READ apiClient WRITE setApiClient)
+    Q_PROPERTY(QString controllingSessionId READ controllingSessionId NOTIFY controllingSessionIdChanged)
+    Q_PROPERTY(QString controllingSessionName READ controllingSessionName NOTIFY controllingSessionNameChanged)
+    /**
+     * Whether the playback is done by this client
+     */
+    Q_PROPERTY(bool controllingSessionLocal READ controllingSessionLocal NOTIFY controllingSessionLocalChanged)
+
     Q_PROPERTY(int audioIndex READ audioIndex WRITE setAudioIndex NOTIFY audioIndexChanged)
     Q_PROPERTY(int subtitleIndex READ subtitleIndex WRITE setSubtitleIndex NOTIFY subtitleIndexChanged)
     Q_PROPERTY(QString streamUrl READ streamUrl NOTIFY streamUrlChanged)
@@ -91,7 +100,7 @@ public:
     Q_PROPERTY(bool resumePlayback READ resumePlayback WRITE setResumePlayback NOTIFY resumePlaybackChanged)
     Q_PROPERTY(Jellyfin::DTO::PlayMethodClass::Value playMethod READ playMethod NOTIFY playMethodChanged)
 
-    // Current Item and queue informatoion
+    // Current Item and queue information
     Q_PROPERTY(QObject *item READ item NOTIFY itemChanged)
     Q_PROPERTY(int queueIndex READ queueIndex NOTIFY queueIndexChanged)
     Q_PROPERTY(Jellyfin::ViewModel::Playlist *queue READ queue NOTIFY queueChanged)
@@ -124,6 +133,11 @@ public:
     ViewModel::Item *item() const;
     QSharedPointer<Model::Item> dataItem() const;
 
+    QSharedPointer<Model::ControllableSession> controllingSession() const;
+    void setControllingSession(QSharedPointer<Model::ControllableSession> session);
+    QString controllingSessionId() const;
+    QString controllingSessionName() const;
+    bool controllingSessionLocal() const;
     QString streamUrl() const;
     PlayMethod playMethod() const;
     qint64 position() const;
@@ -146,6 +160,10 @@ public:
     void setHandlePlaystateCommands(bool newHandlePlaystateCommands);
 signals:
     void itemChanged();
+    void controllingSessionChanged();
+    void controllingSessionIdChanged();
+    void controllingSessionNameChanged();
+    void controllingSessionLocalChanged();
     void streamUrlChanged(const QString &newStreamUrl);
     void autoOpenChanged(bool autoOpen);
     void audioIndexChanged(int audioIndex);

--- a/core/include/JellyfinQt/viewmodel/playlist.h
+++ b/core/include/JellyfinQt/viewmodel/playlist.h
@@ -71,6 +71,7 @@ public:
     QVariant data(const QModelIndex &parent, int role = Qt::DisplayRole) const override;
     int rowCount(const QModelIndex &parent) const override;
     QHash<int, QByteArray> roleNames() const override;
+    void setPlaylistModel(Model::Playlist *data);
 
 
 private slots:

--- a/core/include/JellyfinQt/viewmodel/remotedevice.h
+++ b/core/include/JellyfinQt/viewmodel/remotedevice.h
@@ -1,0 +1,118 @@
+/*
+ * Sailfin: a Jellyfin client written using Qt
+ * Copyright (C) 2022 Chris Josten and the Sailfin Contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef JELLYFIN_VIEWMODEL_REMOTEDEVICE_H
+#define JELLYFIN_VIEWMODEL_REMOTEDEVICE_H
+
+#include <JellyfinQt/model/controllablesession.h>
+
+#include <QAbstractItemModel>
+#include <QList>
+#include <QObject>
+#include <QQmlParserStatus>
+#include <QSharedPointer>
+
+#include <utility>
+
+namespace Jellyfin {
+
+class ApiClient;
+
+namespace ViewModel {
+
+class PlaybackManager;
+
+/**
+ * @brief AbstractListModel of remotely controllable devices by JellyfinQt.
+ *
+ * This class controls a set of \link ViewModel::RemoteSessionScanner RemoteSessionScanners\endlink and
+ * puts their found devices in this list.
+ */
+class RemoteDeviceList : public QAbstractListModel, public QQmlParserStatus {
+    Q_OBJECT
+    Q_INTERFACES(QQmlParserStatus)
+
+    /**
+     * The ApiClient for interacting with the Jellyfin API.
+     */
+    Q_PROPERTY(Jellyfin::ApiClient* apiClient READ apiClient WRITE setApiClient NOTIFY apiClientChanged)
+    /**
+     * Gets/sets whether the model is scanning for other devices.
+     */
+    Q_PROPERTY(bool scanning READ scanning WRITE setScanning NOTIFY scanningChanged);
+public:
+    enum RoleNames {
+        jellyfinId = Qt::UserRole + 1,
+        name,
+        deviceName,
+        deviceType,
+        userName,
+        session
+    };
+
+    explicit RemoteDeviceList(QObject *parent = nullptr);
+
+    ApiClient *apiClient() const { return m_apiClient; }
+    void setApiClient(ApiClient *apiClient);
+
+    bool scanning() const { return m_scanning; }
+    void setScanning(bool scanning);
+
+    // QAbstractListModel
+    int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+    QVariant data(const QModelIndex &index, int role) const override;
+    QHash<int, QByteArray> roleNames() const override {
+        return {
+            { RoleNames::jellyfinId, "jellyfinId"},
+            { RoleNames::name,       "name"       },
+            { RoleNames::deviceName, "deviceName" },
+            { RoleNames::deviceType, "deviceType" },
+            { RoleNames::userName,   "userName"   },
+            { RoleNames::session,    "session"    }
+        };
+    }
+
+    /**
+     * @brief Sets the PlaybackManager to control the session at the given index in this model
+     * @param manager The PlaybackManager
+     * @param index The index of the session that should be controlled
+     */
+    Q_INVOKABLE void activateSession(Jellyfin::ViewModel::PlaybackManager *manager, int index);
+
+    // QQmlParserStatus
+    void classBegin() override;
+    void componentComplete() override;
+signals:
+    void apiClientChanged();
+    void scanningChanged();
+private slots:
+    void onSessionFound(Jellyfin::Model::ControllableSession * session);
+    void onSessionLost(QString sessionId);
+    void onSessionsReset();
+private:
+    ApiClient *m_apiClient = nullptr;
+    bool m_scanning = false;
+    bool m_componentComplete = false;
+    QList<std::pair<Model::RemoteSessionScanner *, QSharedPointer<Model::ControllableSession>>> m_sessions;
+    QList<Model::RemoteSessionScanner *> m_scanners;
+};
+
+} // NS ViewModel
+} // NS Jellyfin
+
+#endif // JELLYFIN_VIEWMODEL_REMOTEDEVICE_H

--- a/core/include/JellyfinQt/viewmodel/usermodel.h
+++ b/core/include/JellyfinQt/viewmodel/usermodel.h
@@ -43,17 +43,17 @@ public:
         userId = Qt::UserRole + 1,
         name,
         hasPassword,
-        primaryImageTag,
+        primaryImageTag
     };
 
     explicit UserModel (QObject *parent = nullptr);
 
     virtual QHash<int, QByteArray> roleNames() const override {
         return {
-            { RoleNames::userId,                    "userId"                    },
-            { RoleNames::name,                      "name"                      },
-            { RoleNames::hasPassword,               "hasPassword"               },
-            { RoleNames::primaryImageTag,           "primaryImageTag"           },
+            { RoleNames::userId,                    "userId"          },
+            { RoleNames::name,                      "name"            },
+            { RoleNames::hasPassword,               "hasPassword"     },
+            { RoleNames::primaryImageTag,           "primaryImageTag" }
         };
     }
     QVariant data(const QModelIndex &index, int role) const override;

--- a/core/include/JellyfinQt/websocket.h
+++ b/core/include/JellyfinQt/websocket.h
@@ -60,9 +60,30 @@ public:
      */
     explicit WebSocket(ApiClient *client);
     enum MessageType {
+        /**
+         * @brief Server to client: instruct client to send periodical KeepAlive messages
+         */
         ForceKeepAlive,
+        /**
+         * @brief Client to server: keep the connection alive
+         */
         KeepAlive,
-        UserDataChanged
+        /**
+         * @brief Server to client: user data for an item has changed.
+         */
+        UserDataChanged,
+        /**
+         * @brief Client to server: Subscribe to playback update sessions.
+         */
+        SessionsStart,
+        /**
+         * @brief Client to server: unsubscribe from playback session updates
+         */
+        SessionsStop,
+        /**
+         * @brief Server to client: session information has changed
+         */
+        Sessions
     };
     Q_PROPERTY(QAbstractSocket::SocketState state READ state NOTIFY stateChanged)
     Q_ENUM(MessageType)
@@ -72,6 +93,8 @@ public:
     }
 public slots:
     void open();
+    void subscribeToSessionInfo();
+    void unsubscribeToSessionInfo();
 private slots:
     void textMessageReceived(const QString &message);
     void onConnected();
@@ -80,7 +103,7 @@ private slots:
     void sendKeepAlive();
     void onWebsocketStateChanged(QAbstractSocket::SocketState newState) { emit stateChanged(newState); }
 signals:
-    void commandReceived(QString arts, QVariantMap args);
+    void commandReceived(QString command, QVariantMap args);
     void stateChanged(QAbstractSocket::SocketState newState);
 
 protected:
@@ -90,6 +113,7 @@ protected:
     QTimer m_keepAliveTimer;
     QTimer m_retryTimer;
     int m_reconnectAttempt = 0;
+    int m_sessionInfoSubscribeCount = 0;
 
 
     void setupKeepAlive(int data);

--- a/core/openapi.json
+++ b/core/openapi.json
@@ -34508,6 +34508,41 @@
               "format": "int64",
               "nullable": true
             }
+          },
+          {
+            "name": "mediaSourceId",
+            "in": "query",
+            "description": "Optional. The media source id.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "audioStreamIndex",
+            "in": "query",
+            "description": "Optional. The index of the audio stream to play.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "subtitleStreamIndex",
+            "in": "query",
+            "description": "Optional. The index of the subtitle stream to play.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "startIndex",
+            "in": "query",
+            "description": "Optional. The start index.",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
           }
         ],
         "responses": {

--- a/core/openapigenerator.d
+++ b/core/openapigenerator.d
@@ -457,7 +457,11 @@ void generateFileForEndpoints(ref const Node[] endpointNodes,
 						}
 					}
 				}
-				}
+			}
+			if (codeNo == 204 /* No content */) {
+				endpoint.resultType = "void";
+				endpoint.hasSuccessResponse = true;
+			}
 		}
 		
 		if ("requestBody" in endpointNode) {

--- a/core/src/apiclient.cpp
+++ b/core/src/apiclient.cpp
@@ -44,6 +44,7 @@ public:
     // Authentication-related variables
     QString token;
     QString baseUrl;
+    QString appName;
     QString deviceName;
     QString deviceId;
     QString userId;
@@ -101,6 +102,21 @@ void ApiClient::setBaseUrl(const QString &url) {
         d->baseUrl.chop(1);
     }
     emit this->baseUrlChanged(d->baseUrl);
+}
+
+const QString &ApiClient::appName() const {
+    const Q_D(ApiClient);
+    return d->appName;
+}
+
+void ApiClient::setAppName(const QString &name) {
+    Q_D(ApiClient);
+    d->appName = name;
+    emit appNameChanged(name);
+
+    if (!d->componentBeingParsed) {
+        generateDeviceProfile();
+    }
 }
 
 const QString &ApiClient::userId() const {
@@ -220,7 +236,7 @@ void ApiClient::addBaseRequestHeaders(QNetworkRequest &request, const QString &p
 void ApiClient::addTokenHeader(QNetworkRequest &request) const {
     Q_D(const ApiClient);
     QString authentication =   "MediaBrowser ";
-    authentication        +=   "Client=\"Sailfin\"";
+    authentication        +=   "Client=\"" +d->appName +"\"";
     authentication        += ", Device=\"" + d->deviceName + "\"";
     authentication        += ", DeviceId=\"" + d->deviceId + "\"";
     authentication        += ", Version=\"" + version() + "\"";
@@ -425,7 +441,6 @@ QString ApiClient::downloadUrl(const QString &itemId) const {
 void ApiClient::generateDeviceProfile() {
     Q_D(ApiClient);
     QSharedPointer<DTO::DeviceProfile> deviceProfile = QSharedPointer<DTO::DeviceProfile>::create(Model::DeviceProfile::generateProfile());
-    deviceProfile->setName(d->deviceName);
     deviceProfile->setJellyfinId(d->deviceId);
     deviceProfile->setFriendlyName(QSysInfo::prettyProductName());
     deviceProfile->setMaxStreamingBitrate(d->settings->maxStreamingBitRate());

--- a/core/src/apiclient.cpp
+++ b/core/src/apiclient.cpp
@@ -47,6 +47,7 @@ public:
     QString appName;
     QString deviceName;
     QString deviceId;
+    Model::DeviceType deviceType = Model::DeviceType::Unknown;
     QString userId;
 
     bool online = true;
@@ -133,6 +134,17 @@ void ApiClient::setUserId(const QString &userId) {
 const QString &ApiClient::deviceId() const {
     Q_D(const ApiClient);
     return d->deviceId;
+}
+
+Model::DeviceType ApiClient::deviceType() const {
+    Q_D(const ApiClient);
+    return d->deviceType;
+}
+
+void ApiClient::setDeviceType(Model::DeviceType newDeviceType) {
+    Q_D(ApiClient);
+    d->deviceType =newDeviceType;
+    emit deviceTypeChanged();
 }
 
 EventBus *ApiClient::eventbus() const {

--- a/core/src/jellyfin.cpp
+++ b/core/src/jellyfin.cpp
@@ -30,6 +30,7 @@
 #include "JellyfinQt/eventbus.h"
 #include "JellyfinQt/serverdiscoverymodel.h"
 #include "JellyfinQt/websocket.h"
+#include "JellyfinQt/model/controllablesession.h"
 #include "JellyfinQt/model/player.h"
 #include "JellyfinQt/viewmodel/item.h"
 #include "JellyfinQt/viewmodel/itemmodel.h"
@@ -39,6 +40,7 @@
 #include "JellyfinQt/viewmodel/platformmediacontrol.h"
 #include "JellyfinQt/viewmodel/playbackmanager.h"
 #include "JellyfinQt/viewmodel/playlist.h"
+#include "JellyfinQt/viewmodel/remotedevice.h"
 #include "JellyfinQt/viewmodel/settings.h"
 #include "JellyfinQt/viewmodel/userdata.h"
 #include "JellyfinQt/viewmodel/usermodel.h"
@@ -66,6 +68,7 @@ void JellyfinPlugin::registerTypes(const char *uri) {
     qmlRegisterType<ViewModel::ItemModel>(uri, 1, 0, "ItemModel");
     qmlRegisterType<ViewModel::UserModel>(uri, 1, 0, "UserModel");
     qmlRegisterUncreatableType<ViewModel::Playlist>(uri, 1, 0, "Playlist", "Available via PlaybackManager");
+    qmlRegisterType<ViewModel::RemoteDeviceList>(uri, 1, 0, "RemoteDeviceList");
 
     // Loaders
     qmlRegisterUncreatableType<ViewModel::LoaderBase>(uri, 1, 0, "LoaderBase", "Use one of its subclasses");
@@ -90,6 +93,7 @@ void JellyfinPlugin::registerTypes(const char *uri) {
     qmlRegisterUncreatableType<Jellyfin::ViewModel::NowPlayingSection>(uri, 1, 0, "NowPlayingSection", "Is an enum");
     qmlRegisterUncreatableType<Jellyfin::Model::PlayerStateClass>(uri, 1, 0, "PlayerState", "Is an enum");
     qmlRegisterUncreatableType<Jellyfin::Model::MediaStatusClass>(uri, 1, 0, "MediaStatus", "Is an enum");
+    qmlRegisterUncreatableType<Jellyfin::Model::DeviceTypeClass>(uri, 1, 0, "DeviceType", "Is an enum");
 
     qRegisterMetaType<Jellyfin::DTO::PlayMethodClass::Value>();
 }

--- a/core/src/loader/http/apikey.cpp
+++ b/core/src/loader/http/apikey.cpp
@@ -64,6 +64,65 @@ QNetworkAccessManager::Operation GetKeysLoader::operation() const {
 
 }
 
+CreateKeyLoader::CreateKeyLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CreateKeyParams>(apiClient) {}
+
+QString CreateKeyLoader::path(const CreateKeyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Auth/Keys");
+}
+
+QUrlQuery CreateKeyLoader::query(const CreateKeyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("app", Support::toString<QString>(params.app()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CreateKeyLoader::body(const CreateKeyParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation CreateKeyLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+RevokeKeyLoader::RevokeKeyLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RevokeKeyParams>(apiClient) {}
+
+QString RevokeKeyLoader::path(const RevokeKeyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Auth/Keys/") + Support::toString< QString>(params.key()) ;
+}
+
+QUrlQuery RevokeKeyLoader::query(const RevokeKeyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray RevokeKeyLoader::body(const RevokeKeyParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RevokeKeyLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/branding.cpp
+++ b/core/src/loader/http/branding.cpp
@@ -65,7 +65,7 @@ QNetworkAccessManager::Operation GetBrandingOptionsLoader::operation() const {
 }
 
 GetBrandingCssLoader::GetBrandingCssLoader(ApiClient *apiClient)
-	: Jellyfin::Support::HttpLoader<QString, GetBrandingCssParams>(apiClient) {}
+	: Jellyfin::Support::HttpLoader<void, GetBrandingCssParams>(apiClient) {}
 
 QString GetBrandingCssLoader::path(const GetBrandingCssParams &params) const {
 	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
@@ -94,7 +94,7 @@ QNetworkAccessManager::Operation GetBrandingCssLoader::operation() const {
 }
 
 GetBrandingCss_2Loader::GetBrandingCss_2Loader(ApiClient *apiClient)
-	: Jellyfin::Support::HttpLoader<QString, GetBrandingCss_2Params>(apiClient) {}
+	: Jellyfin::Support::HttpLoader<void, GetBrandingCss_2Params>(apiClient) {}
 
 QString GetBrandingCss_2Loader::path(const GetBrandingCss_2Params &params) const {
 	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings

--- a/core/src/loader/http/collection.cpp
+++ b/core/src/loader/http/collection.cpp
@@ -76,6 +76,66 @@ QNetworkAccessManager::Operation CreateCollectionLoader::operation() const {
 
 }
 
+AddToCollectionLoader::AddToCollectionLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, AddToCollectionParams>(apiClient) {}
+
+QString AddToCollectionLoader::path(const AddToCollectionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Collections/") + Support::toString< QString>(params.collectionId()) + QStringLiteral("/Items");
+}
+
+QUrlQuery AddToCollectionLoader::query(const AddToCollectionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("ids", Support::toString<QStringList>(params.ids()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray AddToCollectionLoader::body(const AddToCollectionParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation AddToCollectionLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+RemoveFromCollectionLoader::RemoveFromCollectionLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RemoveFromCollectionParams>(apiClient) {}
+
+QString RemoveFromCollectionLoader::path(const RemoveFromCollectionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Collections/") + Support::toString< QString>(params.collectionId()) + QStringLiteral("/Items");
+}
+
+QUrlQuery RemoveFromCollectionLoader::query(const RemoveFromCollectionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("ids", Support::toString<QStringList>(params.ids()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray RemoveFromCollectionLoader::body(const RemoveFromCollectionParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RemoveFromCollectionLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/configuration.cpp
+++ b/core/src/loader/http/configuration.cpp
@@ -64,6 +64,35 @@ QNetworkAccessManager::Operation GetConfigurationLoader::operation() const {
 
 }
 
+UpdateConfigurationLoader::UpdateConfigurationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateConfigurationParams>(apiClient) {}
+
+QString UpdateConfigurationLoader::path(const UpdateConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/System/Configuration");
+}
+
+QUrlQuery UpdateConfigurationLoader::query(const UpdateConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateConfigurationLoader::body(const UpdateConfigurationParams &params) const {
+	return Support::toString<QSharedPointer<ServerConfiguration>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateConfigurationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetNamedConfigurationLoader::GetNamedConfigurationLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QString, GetNamedConfigurationParams>(apiClient) {}
 
@@ -93,6 +122,35 @@ QNetworkAccessManager::Operation GetNamedConfigurationLoader::operation() const 
 
 }
 
+UpdateNamedConfigurationLoader::UpdateNamedConfigurationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateNamedConfigurationParams>(apiClient) {}
+
+QString UpdateNamedConfigurationLoader::path(const UpdateNamedConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/System/Configuration/") + Support::toString< QString>(params.key()) ;
+}
+
+QUrlQuery UpdateNamedConfigurationLoader::query(const UpdateNamedConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateNamedConfigurationLoader::body(const UpdateNamedConfigurationParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation UpdateNamedConfigurationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetDefaultMetadataOptionsLoader::GetDefaultMetadataOptionsLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<MetadataOptions, GetDefaultMetadataOptionsParams>(apiClient) {}
 
@@ -119,6 +177,35 @@ QByteArray GetDefaultMetadataOptionsLoader::body(const GetDefaultMetadataOptions
 QNetworkAccessManager::Operation GetDefaultMetadataOptionsLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+UpdateMediaEncoderPathLoader::UpdateMediaEncoderPathLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateMediaEncoderPathParams>(apiClient) {}
+
+QString UpdateMediaEncoderPathLoader::path(const UpdateMediaEncoderPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/System/MediaEncoder/Path");
+}
+
+QUrlQuery UpdateMediaEncoderPathLoader::query(const UpdateMediaEncoderPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateMediaEncoderPathLoader::body(const UpdateMediaEncoderPathParams &params) const {
+	return Support::toString<QSharedPointer<MediaEncoderPathDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateMediaEncoderPathLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/devices.cpp
+++ b/core/src/loader/http/devices.cpp
@@ -70,6 +70,36 @@ QNetworkAccessManager::Operation GetDevicesLoader::operation() const {
 
 }
 
+DeleteDeviceLoader::DeleteDeviceLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteDeviceParams>(apiClient) {}
+
+QString DeleteDeviceLoader::path(const DeleteDeviceParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Devices");
+}
+
+QUrlQuery DeleteDeviceLoader::query(const DeleteDeviceParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("id", Support::toString<QString>(params.jellyfinId()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteDeviceLoader::body(const DeleteDeviceParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteDeviceLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 GetDeviceInfoLoader::GetDeviceInfoLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<DeviceInfo, GetDeviceInfoParams>(apiClient) {}
 
@@ -127,6 +157,36 @@ QByteArray GetDeviceOptionsLoader::body(const GetDeviceOptionsParams &params) co
 QNetworkAccessManager::Operation GetDeviceOptionsLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+UpdateDeviceOptionsLoader::UpdateDeviceOptionsLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateDeviceOptionsParams>(apiClient) {}
+
+QString UpdateDeviceOptionsLoader::path(const UpdateDeviceOptionsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Devices/Options");
+}
+
+QUrlQuery UpdateDeviceOptionsLoader::query(const UpdateDeviceOptionsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("id", Support::toString<QString>(params.jellyfinId()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateDeviceOptionsLoader::body(const UpdateDeviceOptionsParams &params) const {
+	return Support::toString<QSharedPointer<DeviceOptions>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateDeviceOptionsLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/displaypreferences.cpp
+++ b/core/src/loader/http/displaypreferences.cpp
@@ -66,6 +66,37 @@ QNetworkAccessManager::Operation GetDisplayPreferencesLoader::operation() const 
 
 }
 
+UpdateDisplayPreferencesLoader::UpdateDisplayPreferencesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateDisplayPreferencesParams>(apiClient) {}
+
+QString UpdateDisplayPreferencesLoader::path(const UpdateDisplayPreferencesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/DisplayPreferences/") + Support::toString< QString>(params.displayPreferencesId()) ;
+}
+
+QUrlQuery UpdateDisplayPreferencesLoader::query(const UpdateDisplayPreferencesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("userId", Support::toString<QString>(params.userId()));
+	result.addQueryItem("client", Support::toString<QString>(params.client()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateDisplayPreferencesLoader::body(const UpdateDisplayPreferencesParams &params) const {
+	return Support::toString<QSharedPointer<DisplayPreferencesDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateDisplayPreferencesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/dlna.cpp
+++ b/core/src/loader/http/dlna.cpp
@@ -64,6 +64,35 @@ QNetworkAccessManager::Operation GetProfileInfosLoader::operation() const {
 
 }
 
+CreateProfileLoader::CreateProfileLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CreateProfileParams>(apiClient) {}
+
+QString CreateProfileLoader::path(const CreateProfileParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Dlna/Profiles");
+}
+
+QUrlQuery CreateProfileLoader::query(const CreateProfileParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CreateProfileLoader::body(const CreateProfileParams &params) const {
+	return Support::toString<QSharedPointer<DeviceProfile>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation CreateProfileLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetProfileLoader::GetProfileLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<DeviceProfile, GetProfileParams>(apiClient) {}
 
@@ -90,6 +119,64 @@ QByteArray GetProfileLoader::body(const GetProfileParams &params) const {
 QNetworkAccessManager::Operation GetProfileLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+DeleteProfileLoader::DeleteProfileLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteProfileParams>(apiClient) {}
+
+QString DeleteProfileLoader::path(const DeleteProfileParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Dlna/Profiles/") + Support::toString< QString>(params.profileId()) ;
+}
+
+QUrlQuery DeleteProfileLoader::query(const DeleteProfileParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteProfileLoader::body(const DeleteProfileParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteProfileLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+UpdateProfileLoader::UpdateProfileLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateProfileParams>(apiClient) {}
+
+QString UpdateProfileLoader::path(const UpdateProfileParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Dlna/Profiles/") + Support::toString< QString>(params.profileId()) ;
+}
+
+QUrlQuery UpdateProfileLoader::query(const UpdateProfileParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateProfileLoader::body(const UpdateProfileParams &params) const {
+	return Support::toString<QSharedPointer<DeviceProfile>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateProfileLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/environment.cpp
+++ b/core/src/loader/http/environment.cpp
@@ -188,6 +188,35 @@ QNetworkAccessManager::Operation GetParentPathLoader::operation() const {
 
 }
 
+ValidatePathLoader::ValidatePathLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ValidatePathParams>(apiClient) {}
+
+QString ValidatePathLoader::path(const ValidatePathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Environment/ValidatePath");
+}
+
+QUrlQuery ValidatePathLoader::query(const ValidatePathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ValidatePathLoader::body(const ValidatePathParams &params) const {
+	return Support::toString<QSharedPointer<ValidatePathDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation ValidatePathLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/hlssegment.cpp
+++ b/core/src/loader/http/hlssegment.cpp
@@ -35,6 +35,41 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+StopEncodingProcessLoader::StopEncodingProcessLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, StopEncodingProcessParams>(apiClient) {}
+
+QString StopEncodingProcessLoader::path(const StopEncodingProcessParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Videos/ActiveEncodings");
+}
+
+QUrlQuery StopEncodingProcessLoader::query(const StopEncodingProcessParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.deviceIdNull()) {
+		result.addQueryItem("deviceId", Support::toString<QString>(params.deviceId()));
+	}
+	if (!params.playSessionIdNull()) {
+		result.addQueryItem("playSessionId", Support::toString<QString>(params.playSessionId()));
+	}
+	
+	return result;
+}
+
+QByteArray StopEncodingProcessLoader::body(const StopEncodingProcessParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation StopEncodingProcessLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/image.cpp
+++ b/core/src/loader/http/image.cpp
@@ -64,6 +64,279 @@ QNetworkAccessManager::Operation GetItemImageInfosLoader::operation() const {
 
 }
 
+DeleteItemImageLoader::DeleteItemImageLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteItemImageParams>(apiClient) {}
+
+QString DeleteItemImageLoader::path(const DeleteItemImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) ;
+}
+
+QUrlQuery DeleteItemImageLoader::query(const DeleteItemImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.imageIndexNull()) {
+		result.addQueryItem("imageIndex", Support::toString<std::optional<qint32>>(params.imageIndex()));
+	}
+	
+	return result;
+}
+
+QByteArray DeleteItemImageLoader::body(const DeleteItemImageParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteItemImageLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+SetItemImageLoader::SetItemImageLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SetItemImageParams>(apiClient) {}
+
+QString SetItemImageLoader::path(const SetItemImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) ;
+}
+
+QUrlQuery SetItemImageLoader::query(const SetItemImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SetItemImageLoader::body(const SetItemImageParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SetItemImageLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+DeleteItemImageByIndexLoader::DeleteItemImageByIndexLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteItemImageByIndexParams>(apiClient) {}
+
+QString DeleteItemImageByIndexLoader::path(const DeleteItemImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) + QStringLiteral("/") + Support::toString< qint32>(params.imageIndex()) ;
+}
+
+QUrlQuery DeleteItemImageByIndexLoader::query(const DeleteItemImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteItemImageByIndexLoader::body(const DeleteItemImageByIndexParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteItemImageByIndexLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+SetItemImageByIndexLoader::SetItemImageByIndexLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SetItemImageByIndexParams>(apiClient) {}
+
+QString SetItemImageByIndexLoader::path(const SetItemImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) + QStringLiteral("/") + Support::toString< qint32>(params.imageIndex()) ;
+}
+
+QUrlQuery SetItemImageByIndexLoader::query(const SetItemImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SetItemImageByIndexLoader::body(const SetItemImageByIndexParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SetItemImageByIndexLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UpdateItemImageIndexLoader::UpdateItemImageIndexLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateItemImageIndexParams>(apiClient) {}
+
+QString UpdateItemImageIndexLoader::path(const UpdateItemImageIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) + QStringLiteral("/") + Support::toString< qint32>(params.imageIndex()) + QStringLiteral("/Index");
+}
+
+QUrlQuery UpdateItemImageIndexLoader::query(const UpdateItemImageIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.newIndexNull()) {
+		result.addQueryItem("newIndex", Support::toString<std::optional<qint32>>(params.newIndex()));
+	}
+	
+	return result;
+}
+
+QByteArray UpdateItemImageIndexLoader::body(const UpdateItemImageIndexParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation UpdateItemImageIndexLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+PostUserImageLoader::PostUserImageLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostUserImageParams>(apiClient) {}
+
+QString PostUserImageLoader::path(const PostUserImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) ;
+}
+
+QUrlQuery PostUserImageLoader::query(const PostUserImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.indexNull()) {
+		result.addQueryItem("index", Support::toString<std::optional<qint32>>(params.index()));
+	}
+	
+	return result;
+}
+
+QByteArray PostUserImageLoader::body(const PostUserImageParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostUserImageLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+DeleteUserImageLoader::DeleteUserImageLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteUserImageParams>(apiClient) {}
+
+QString DeleteUserImageLoader::path(const DeleteUserImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) ;
+}
+
+QUrlQuery DeleteUserImageLoader::query(const DeleteUserImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.indexNull()) {
+		result.addQueryItem("index", Support::toString<std::optional<qint32>>(params.index()));
+	}
+	
+	return result;
+}
+
+QByteArray DeleteUserImageLoader::body(const DeleteUserImageParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteUserImageLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+PostUserImageByIndexLoader::PostUserImageByIndexLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostUserImageByIndexParams>(apiClient) {}
+
+QString PostUserImageByIndexLoader::path(const PostUserImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) + QStringLiteral("/") + Support::toString< qint32>(params.index()) ;
+}
+
+QUrlQuery PostUserImageByIndexLoader::query(const PostUserImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray PostUserImageByIndexLoader::body(const PostUserImageByIndexParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostUserImageByIndexLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+DeleteUserImageByIndexLoader::DeleteUserImageByIndexLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteUserImageByIndexParams>(apiClient) {}
+
+QString DeleteUserImageByIndexLoader::path(const DeleteUserImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Images/") + Support::toString< ImageType>(params.imageType()) + QStringLiteral("/") + Support::toString< qint32>(params.index()) ;
+}
+
+QUrlQuery DeleteUserImageByIndexLoader::query(const DeleteUserImageByIndexParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteUserImageByIndexLoader::body(const DeleteUserImageByIndexParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteUserImageByIndexLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/itemlookup.cpp
+++ b/core/src/loader/http/itemlookup.cpp
@@ -64,6 +64,38 @@ QNetworkAccessManager::Operation GetExternalIdInfosLoader::operation() const {
 
 }
 
+ApplySearchCriteriaLoader::ApplySearchCriteriaLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ApplySearchCriteriaParams>(apiClient) {}
+
+QString ApplySearchCriteriaLoader::path(const ApplySearchCriteriaParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/RemoteSearch/Apply/") + Support::toString< QString>(params.itemId()) ;
+}
+
+QUrlQuery ApplySearchCriteriaLoader::query(const ApplySearchCriteriaParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.replaceAllImagesNull()) {
+		result.addQueryItem("replaceAllImages", Support::toString<std::optional<bool>>(params.replaceAllImages()));
+	}
+	
+	return result;
+}
+
+QByteArray ApplySearchCriteriaLoader::body(const ApplySearchCriteriaParams &params) const {
+	return Support::toString<QSharedPointer<RemoteSearchResult>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation ApplySearchCriteriaLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetBookRemoteSearchResultsLoader::GetBookRemoteSearchResultsLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QList<RemoteSearchResult>, GetBookRemoteSearchResultsParams>(apiClient) {}
 

--- a/core/src/loader/http/itemrefresh.cpp
+++ b/core/src/loader/http/itemrefresh.cpp
@@ -35,6 +35,47 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+PostLoader::PostLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostParams>(apiClient) {}
+
+QString PostLoader::path(const PostParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Refresh");
+}
+
+QUrlQuery PostLoader::query(const PostParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.metadataRefreshModeNull()) {
+		result.addQueryItem("metadataRefreshMode", Support::toString<MetadataRefreshMode>(params.metadataRefreshMode()));
+	}
+	if (!params.imageRefreshModeNull()) {
+		result.addQueryItem("imageRefreshMode", Support::toString<MetadataRefreshMode>(params.imageRefreshMode()));
+	}
+	if (!params.replaceAllMetadataNull()) {
+		result.addQueryItem("replaceAllMetadata", Support::toString<std::optional<bool>>(params.replaceAllMetadata()));
+	}
+	if (!params.replaceAllImagesNull()) {
+		result.addQueryItem("replaceAllImages", Support::toString<std::optional<bool>>(params.replaceAllImages()));
+	}
+	
+	return result;
+}
+
+QByteArray PostLoader::body(const PostParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/itemupdate.cpp
+++ b/core/src/loader/http/itemupdate.cpp
@@ -35,6 +35,67 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+UpdateItemLoader::UpdateItemLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateItemParams>(apiClient) {}
+
+QString UpdateItemLoader::path(const UpdateItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) ;
+}
+
+QUrlQuery UpdateItemLoader::query(const UpdateItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateItemLoader::body(const UpdateItemParams &params) const {
+	return Support::toString<QSharedPointer<BaseItemDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateItemLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UpdateItemContentTypeLoader::UpdateItemContentTypeLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateItemContentTypeParams>(apiClient) {}
+
+QString UpdateItemContentTypeLoader::path(const UpdateItemContentTypeParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/ContentType");
+}
+
+QUrlQuery UpdateItemContentTypeLoader::query(const UpdateItemContentTypeParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.contentTypeNull()) {
+		result.addQueryItem("contentType", Support::toString<QString>(params.contentType()));
+	}
+	
+	return result;
+}
+
+QByteArray UpdateItemContentTypeLoader::body(const UpdateItemContentTypeParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation UpdateItemContentTypeLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetMetadataEditorInfoLoader::GetMetadataEditorInfoLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<MetadataEditorInfo, GetMetadataEditorInfoParams>(apiClient) {}
 

--- a/core/src/loader/http/library.cpp
+++ b/core/src/loader/http/library.cpp
@@ -35,6 +35,67 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+DeleteItemsLoader::DeleteItemsLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteItemsParams>(apiClient) {}
+
+QString DeleteItemsLoader::path(const DeleteItemsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items");
+}
+
+QUrlQuery DeleteItemsLoader::query(const DeleteItemsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.idsNull()) {
+		result.addQueryItem("ids", Support::toString<QStringList>(params.ids()));
+	}
+	
+	return result;
+}
+
+QByteArray DeleteItemsLoader::body(const DeleteItemsParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteItemsLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+DeleteItemLoader::DeleteItemLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteItemParams>(apiClient) {}
+
+QString DeleteItemLoader::path(const DeleteItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) ;
+}
+
+QUrlQuery DeleteItemLoader::query(const DeleteItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteItemLoader::body(const DeleteItemParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteItemLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 GetSimilarAlbumsLoader::GetSimilarAlbumsLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<BaseItemDtoQueryResult, GetSimilarAlbumsParams>(apiClient) {}
 
@@ -394,6 +455,35 @@ QNetworkAccessManager::Operation GetLibraryOptionsInfoLoader::operation() const 
 
 }
 
+PostUpdatedMediaLoader::PostUpdatedMediaLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostUpdatedMediaParams>(apiClient) {}
+
+QString PostUpdatedMediaLoader::path(const PostUpdatedMediaParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/Media/Updated");
+}
+
+QUrlQuery PostUpdatedMediaLoader::query(const PostUpdatedMediaParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray PostUpdatedMediaLoader::body(const PostUpdatedMediaParams &params) const {
+	return Support::toString<QList<MediaUpdateInfoDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation PostUpdatedMediaLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetMediaFoldersLoader::GetMediaFoldersLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<BaseItemDtoQueryResult, GetMediaFoldersParams>(apiClient) {}
 
@@ -426,6 +516,76 @@ QNetworkAccessManager::Operation GetMediaFoldersLoader::operation() const {
 
 }
 
+PostAddedMoviesLoader::PostAddedMoviesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostAddedMoviesParams>(apiClient) {}
+
+QString PostAddedMoviesLoader::path(const PostAddedMoviesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/Movies/Added");
+}
+
+QUrlQuery PostAddedMoviesLoader::query(const PostAddedMoviesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.tmdbIdNull()) {
+		result.addQueryItem("tmdbId", Support::toString<QString>(params.tmdbId()));
+	}
+	if (!params.imdbIdNull()) {
+		result.addQueryItem("imdbId", Support::toString<QString>(params.imdbId()));
+	}
+	
+	return result;
+}
+
+QByteArray PostAddedMoviesLoader::body(const PostAddedMoviesParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostAddedMoviesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+PostUpdatedMoviesLoader::PostUpdatedMoviesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostUpdatedMoviesParams>(apiClient) {}
+
+QString PostUpdatedMoviesLoader::path(const PostUpdatedMoviesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/Movies/Updated");
+}
+
+QUrlQuery PostUpdatedMoviesLoader::query(const PostUpdatedMoviesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.tmdbIdNull()) {
+		result.addQueryItem("tmdbId", Support::toString<QString>(params.tmdbId()));
+	}
+	if (!params.imdbIdNull()) {
+		result.addQueryItem("imdbId", Support::toString<QString>(params.imdbId()));
+	}
+	
+	return result;
+}
+
+QByteArray PostUpdatedMoviesLoader::body(const PostUpdatedMoviesParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostUpdatedMoviesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetPhysicalPathsLoader::GetPhysicalPathsLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QStringList, GetPhysicalPathsParams>(apiClient) {}
 
@@ -452,6 +612,99 @@ QByteArray GetPhysicalPathsLoader::body(const GetPhysicalPathsParams &params) co
 QNetworkAccessManager::Operation GetPhysicalPathsLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+RefreshLibraryLoader::RefreshLibraryLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RefreshLibraryParams>(apiClient) {}
+
+QString RefreshLibraryLoader::path(const RefreshLibraryParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/Refresh");
+}
+
+QUrlQuery RefreshLibraryLoader::query(const RefreshLibraryParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray RefreshLibraryLoader::body(const RefreshLibraryParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RefreshLibraryLoader::operation() const {
+	// HTTP method Get
+	return QNetworkAccessManager::GetOperation;
+
+}
+
+PostAddedSeriesLoader::PostAddedSeriesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostAddedSeriesParams>(apiClient) {}
+
+QString PostAddedSeriesLoader::path(const PostAddedSeriesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/Series/Added");
+}
+
+QUrlQuery PostAddedSeriesLoader::query(const PostAddedSeriesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.tvdbIdNull()) {
+		result.addQueryItem("tvdbId", Support::toString<QString>(params.tvdbId()));
+	}
+	
+	return result;
+}
+
+QByteArray PostAddedSeriesLoader::body(const PostAddedSeriesParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostAddedSeriesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+PostUpdatedSeriesLoader::PostUpdatedSeriesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostUpdatedSeriesParams>(apiClient) {}
+
+QString PostUpdatedSeriesLoader::path(const PostUpdatedSeriesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/Series/Updated");
+}
+
+QUrlQuery PostUpdatedSeriesLoader::query(const PostUpdatedSeriesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.tvdbIdNull()) {
+		result.addQueryItem("tvdbId", Support::toString<QString>(params.tvdbId()));
+	}
+	
+	return result;
+}
+
+QByteArray PostUpdatedSeriesLoader::body(const PostUpdatedSeriesParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostUpdatedSeriesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/librarystructure.cpp
+++ b/core/src/loader/http/librarystructure.cpp
@@ -64,6 +64,251 @@ QNetworkAccessManager::Operation GetVirtualFoldersLoader::operation() const {
 
 }
 
+AddVirtualFolderLoader::AddVirtualFolderLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, AddVirtualFolderParams>(apiClient) {}
+
+QString AddVirtualFolderLoader::path(const AddVirtualFolderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/VirtualFolders");
+}
+
+QUrlQuery AddVirtualFolderLoader::query(const AddVirtualFolderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.nameNull()) {
+		result.addQueryItem("name", Support::toString<QString>(params.name()));
+	}
+	if (!params.collectionTypeNull()) {
+		result.addQueryItem("collectionType", Support::toString<QString>(params.collectionType()));
+	}
+	if (!params.pathsNull()) {
+		result.addQueryItem("paths", Support::toString<QStringList>(params.paths()));
+	}
+	if (!params.refreshLibraryNull()) {
+		result.addQueryItem("refreshLibrary", Support::toString<std::optional<bool>>(params.refreshLibrary()));
+	}
+	
+	return result;
+}
+
+QByteArray AddVirtualFolderLoader::body(const AddVirtualFolderParams &params) const {
+	return Support::toString<QSharedPointer<AddVirtualFolderDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation AddVirtualFolderLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+RemoveVirtualFolderLoader::RemoveVirtualFolderLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RemoveVirtualFolderParams>(apiClient) {}
+
+QString RemoveVirtualFolderLoader::path(const RemoveVirtualFolderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/VirtualFolders");
+}
+
+QUrlQuery RemoveVirtualFolderLoader::query(const RemoveVirtualFolderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.nameNull()) {
+		result.addQueryItem("name", Support::toString<QString>(params.name()));
+	}
+	if (!params.refreshLibraryNull()) {
+		result.addQueryItem("refreshLibrary", Support::toString<std::optional<bool>>(params.refreshLibrary()));
+	}
+	
+	return result;
+}
+
+QByteArray RemoveVirtualFolderLoader::body(const RemoveVirtualFolderParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RemoveVirtualFolderLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+UpdateLibraryOptionsLoader::UpdateLibraryOptionsLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateLibraryOptionsParams>(apiClient) {}
+
+QString UpdateLibraryOptionsLoader::path(const UpdateLibraryOptionsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/VirtualFolders/LibraryOptions");
+}
+
+QUrlQuery UpdateLibraryOptionsLoader::query(const UpdateLibraryOptionsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateLibraryOptionsLoader::body(const UpdateLibraryOptionsParams &params) const {
+	return Support::toString<QSharedPointer<UpdateLibraryOptionsDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateLibraryOptionsLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+RenameVirtualFolderLoader::RenameVirtualFolderLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RenameVirtualFolderParams>(apiClient) {}
+
+QString RenameVirtualFolderLoader::path(const RenameVirtualFolderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/VirtualFolders/Name");
+}
+
+QUrlQuery RenameVirtualFolderLoader::query(const RenameVirtualFolderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.nameNull()) {
+		result.addQueryItem("name", Support::toString<QString>(params.name()));
+	}
+	if (!params.newNameNull()) {
+		result.addQueryItem("newName", Support::toString<QString>(params.newName()));
+	}
+	if (!params.refreshLibraryNull()) {
+		result.addQueryItem("refreshLibrary", Support::toString<std::optional<bool>>(params.refreshLibrary()));
+	}
+	
+	return result;
+}
+
+QByteArray RenameVirtualFolderLoader::body(const RenameVirtualFolderParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RenameVirtualFolderLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+AddMediaPathLoader::AddMediaPathLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, AddMediaPathParams>(apiClient) {}
+
+QString AddMediaPathLoader::path(const AddMediaPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/VirtualFolders/Paths");
+}
+
+QUrlQuery AddMediaPathLoader::query(const AddMediaPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.refreshLibraryNull()) {
+		result.addQueryItem("refreshLibrary", Support::toString<std::optional<bool>>(params.refreshLibrary()));
+	}
+	
+	return result;
+}
+
+QByteArray AddMediaPathLoader::body(const AddMediaPathParams &params) const {
+	return Support::toString<QSharedPointer<MediaPathDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation AddMediaPathLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+RemoveMediaPathLoader::RemoveMediaPathLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RemoveMediaPathParams>(apiClient) {}
+
+QString RemoveMediaPathLoader::path(const RemoveMediaPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/VirtualFolders/Paths");
+}
+
+QUrlQuery RemoveMediaPathLoader::query(const RemoveMediaPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.nameNull()) {
+		result.addQueryItem("name", Support::toString<QString>(params.name()));
+	}
+	if (!params.pathNull()) {
+		result.addQueryItem("path", Support::toString<QString>(params.path()));
+	}
+	if (!params.refreshLibraryNull()) {
+		result.addQueryItem("refreshLibrary", Support::toString<std::optional<bool>>(params.refreshLibrary()));
+	}
+	
+	return result;
+}
+
+QByteArray RemoveMediaPathLoader::body(const RemoveMediaPathParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RemoveMediaPathLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+UpdateMediaPathLoader::UpdateMediaPathLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateMediaPathParams>(apiClient) {}
+
+QString UpdateMediaPathLoader::path(const UpdateMediaPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Library/VirtualFolders/Paths/Update");
+}
+
+QUrlQuery UpdateMediaPathLoader::query(const UpdateMediaPathParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.nameNull()) {
+		result.addQueryItem("name", Support::toString<QString>(params.name()));
+	}
+	
+	return result;
+}
+
+QByteArray UpdateMediaPathLoader::body(const UpdateMediaPathParams &params) const {
+	return Support::toString<QSharedPointer<MediaPathInfo>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateMediaPathLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/livetv.cpp
+++ b/core/src/loader/http/livetv.cpp
@@ -316,6 +316,38 @@ QNetworkAccessManager::Operation AddListingProviderLoader::operation() const {
 
 }
 
+DeleteListingProviderLoader::DeleteListingProviderLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteListingProviderParams>(apiClient) {}
+
+QString DeleteListingProviderLoader::path(const DeleteListingProviderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/ListingProviders");
+}
+
+QUrlQuery DeleteListingProviderLoader::query(const DeleteListingProviderParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.jellyfinIdNull()) {
+		result.addQueryItem("id", Support::toString<QString>(params.jellyfinId()));
+	}
+	
+	return result;
+}
+
+QByteArray DeleteListingProviderLoader::body(const DeleteListingProviderParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteListingProviderLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 GetDefaultListingProviderLoader::GetDefaultListingProviderLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<ListingsProviderInfo, GetDefaultListingProviderParams>(apiClient) {}
 
@@ -781,6 +813,35 @@ QNetworkAccessManager::Operation GetRecordingLoader::operation() const {
 
 }
 
+DeleteRecordingLoader::DeleteRecordingLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteRecordingParams>(apiClient) {}
+
+QString DeleteRecordingLoader::path(const DeleteRecordingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/Recordings/") + Support::toString< QString>(params.recordingId()) ;
+}
+
+QUrlQuery DeleteRecordingLoader::query(const DeleteRecordingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteRecordingLoader::body(const DeleteRecordingParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteRecordingLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 GetRecordingFoldersLoader::GetRecordingFoldersLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<BaseItemDtoQueryResult, GetRecordingFoldersParams>(apiClient) {}
 
@@ -951,6 +1012,35 @@ QNetworkAccessManager::Operation GetSeriesTimersLoader::operation() const {
 
 }
 
+CreateSeriesTimerLoader::CreateSeriesTimerLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CreateSeriesTimerParams>(apiClient) {}
+
+QString CreateSeriesTimerLoader::path(const CreateSeriesTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/SeriesTimers");
+}
+
+QUrlQuery CreateSeriesTimerLoader::query(const CreateSeriesTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CreateSeriesTimerLoader::body(const CreateSeriesTimerParams &params) const {
+	return Support::toString<QSharedPointer<SeriesTimerInfoDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation CreateSeriesTimerLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetSeriesTimerLoader::GetSeriesTimerLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<SeriesTimerInfoDto, GetSeriesTimerParams>(apiClient) {}
 
@@ -977,6 +1067,64 @@ QByteArray GetSeriesTimerLoader::body(const GetSeriesTimerParams &params) const 
 QNetworkAccessManager::Operation GetSeriesTimerLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+CancelSeriesTimerLoader::CancelSeriesTimerLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CancelSeriesTimerParams>(apiClient) {}
+
+QString CancelSeriesTimerLoader::path(const CancelSeriesTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/SeriesTimers/") + Support::toString< QString>(params.timerId()) ;
+}
+
+QUrlQuery CancelSeriesTimerLoader::query(const CancelSeriesTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CancelSeriesTimerLoader::body(const CancelSeriesTimerParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation CancelSeriesTimerLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+UpdateSeriesTimerLoader::UpdateSeriesTimerLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateSeriesTimerParams>(apiClient) {}
+
+QString UpdateSeriesTimerLoader::path(const UpdateSeriesTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/SeriesTimers/") + Support::toString< QString>(params.timerId()) ;
+}
+
+QUrlQuery UpdateSeriesTimerLoader::query(const UpdateSeriesTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateSeriesTimerLoader::body(const UpdateSeriesTimerParams &params) const {
+	return Support::toString<QSharedPointer<SeriesTimerInfoDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateSeriesTimerLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 
@@ -1021,6 +1169,35 @@ QNetworkAccessManager::Operation GetTimersLoader::operation() const {
 
 }
 
+CreateTimerLoader::CreateTimerLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CreateTimerParams>(apiClient) {}
+
+QString CreateTimerLoader::path(const CreateTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/Timers");
+}
+
+QUrlQuery CreateTimerLoader::query(const CreateTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CreateTimerLoader::body(const CreateTimerParams &params) const {
+	return Support::toString<QSharedPointer<TimerInfoDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation CreateTimerLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetTimerLoader::GetTimerLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<TimerInfoDto, GetTimerParams>(apiClient) {}
 
@@ -1047,6 +1224,64 @@ QByteArray GetTimerLoader::body(const GetTimerParams &params) const {
 QNetworkAccessManager::Operation GetTimerLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+CancelTimerLoader::CancelTimerLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CancelTimerParams>(apiClient) {}
+
+QString CancelTimerLoader::path(const CancelTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/Timers/") + Support::toString< QString>(params.timerId()) ;
+}
+
+QUrlQuery CancelTimerLoader::query(const CancelTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CancelTimerLoader::body(const CancelTimerParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation CancelTimerLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+UpdateTimerLoader::UpdateTimerLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateTimerParams>(apiClient) {}
+
+QString UpdateTimerLoader::path(const UpdateTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/Timers/") + Support::toString< QString>(params.timerId()) ;
+}
+
+QUrlQuery UpdateTimerLoader::query(const UpdateTimerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateTimerLoader::body(const UpdateTimerParams &params) const {
+	return Support::toString<QSharedPointer<TimerInfoDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateTimerLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 
@@ -1111,6 +1346,38 @@ QNetworkAccessManager::Operation AddTunerHostLoader::operation() const {
 
 }
 
+DeleteTunerHostLoader::DeleteTunerHostLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteTunerHostParams>(apiClient) {}
+
+QString DeleteTunerHostLoader::path(const DeleteTunerHostParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/TunerHosts");
+}
+
+QUrlQuery DeleteTunerHostLoader::query(const DeleteTunerHostParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.jellyfinIdNull()) {
+		result.addQueryItem("id", Support::toString<QString>(params.jellyfinId()));
+	}
+	
+	return result;
+}
+
+QByteArray DeleteTunerHostLoader::body(const DeleteTunerHostParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteTunerHostLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 GetTunerHostTypesLoader::GetTunerHostTypesLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QList<NameIdPair>, GetTunerHostTypesParams>(apiClient) {}
 
@@ -1137,6 +1404,35 @@ QByteArray GetTunerHostTypesLoader::body(const GetTunerHostTypesParams &params) 
 QNetworkAccessManager::Operation GetTunerHostTypesLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+ResetTunerLoader::ResetTunerLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ResetTunerParams>(apiClient) {}
+
+QString ResetTunerLoader::path(const ResetTunerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveTv/Tuners/") + Support::toString< QString>(params.tunerId()) + QStringLiteral("/Reset");
+}
+
+QUrlQuery ResetTunerLoader::query(const ResetTunerParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ResetTunerLoader::body(const ResetTunerParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation ResetTunerLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/mediainfo.cpp
+++ b/core/src/loader/http/mediainfo.cpp
@@ -136,6 +136,36 @@ QNetworkAccessManager::Operation GetPostedPlaybackInfoLoader::operation() const 
 
 }
 
+CloseLiveStreamLoader::CloseLiveStreamLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CloseLiveStreamParams>(apiClient) {}
+
+QString CloseLiveStreamLoader::path(const CloseLiveStreamParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/LiveStreams/Close");
+}
+
+QUrlQuery CloseLiveStreamLoader::query(const CloseLiveStreamParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("liveStreamId", Support::toString<QString>(params.liveStreamId()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CloseLiveStreamLoader::body(const CloseLiveStreamParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation CloseLiveStreamLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 OpenLiveStreamLoader::OpenLiveStreamLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<LiveStreamResponse, OpenLiveStreamParams>(apiClient) {}
 

--- a/core/src/loader/http/notifications.cpp
+++ b/core/src/loader/http/notifications.cpp
@@ -64,6 +64,35 @@ QNetworkAccessManager::Operation GetNotificationsLoader::operation() const {
 
 }
 
+SetReadLoader::SetReadLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SetReadParams>(apiClient) {}
+
+QString SetReadLoader::path(const SetReadParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Notifications/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Read");
+}
+
+QUrlQuery SetReadLoader::query(const SetReadParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SetReadLoader::body(const SetReadParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SetReadLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetNotificationsSummaryLoader::GetNotificationsSummaryLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<NotificationsSummaryDto, GetNotificationsSummaryParams>(apiClient) {}
 
@@ -90,6 +119,76 @@ QByteArray GetNotificationsSummaryLoader::body(const GetNotificationsSummaryPara
 QNetworkAccessManager::Operation GetNotificationsSummaryLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+SetUnreadLoader::SetUnreadLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SetUnreadParams>(apiClient) {}
+
+QString SetUnreadLoader::path(const SetUnreadParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Notifications/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Unread");
+}
+
+QUrlQuery SetUnreadLoader::query(const SetUnreadParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SetUnreadLoader::body(const SetUnreadParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SetUnreadLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+CreateAdminNotificationLoader::CreateAdminNotificationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CreateAdminNotificationParams>(apiClient) {}
+
+QString CreateAdminNotificationLoader::path(const CreateAdminNotificationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Notifications/Admin");
+}
+
+QUrlQuery CreateAdminNotificationLoader::query(const CreateAdminNotificationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.urlNull()) {
+		result.addQueryItem("url", Support::toString<QString>(params.url()));
+	}
+	if (!params.levelNull()) {
+		result.addQueryItem("level", Support::toString<NotificationLevel>(params.level()));
+	}
+	if (!params.nameNull()) {
+		result.addQueryItem("name", Support::toString<QString>(params.name()));
+	}
+	if (!params.descriptionNull()) {
+		result.addQueryItem("description", Support::toString<QString>(params.description()));
+	}
+	
+	return result;
+}
+
+QByteArray CreateAdminNotificationLoader::body(const CreateAdminNotificationParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation CreateAdminNotificationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/package.cpp
+++ b/core/src/loader/http/package.cpp
@@ -96,6 +96,73 @@ QNetworkAccessManager::Operation GetPackageInfoLoader::operation() const {
 
 }
 
+InstallPackageLoader::InstallPackageLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, InstallPackageParams>(apiClient) {}
+
+QString InstallPackageLoader::path(const InstallPackageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Packages/Installed/") + Support::toString< QString>(params.name()) ;
+}
+
+QUrlQuery InstallPackageLoader::query(const InstallPackageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.assemblyGuidNull()) {
+		result.addQueryItem("assemblyGuid", Support::toString<QString>(params.assemblyGuid()));
+	}
+	if (!params.versionNull()) {
+		result.addQueryItem("version", Support::toString<QString>(params.version()));
+	}
+	if (!params.repositoryUrlNull()) {
+		result.addQueryItem("repositoryUrl", Support::toString<QString>(params.repositoryUrl()));
+	}
+	
+	return result;
+}
+
+QByteArray InstallPackageLoader::body(const InstallPackageParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation InstallPackageLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+CancelPackageInstallationLoader::CancelPackageInstallationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CancelPackageInstallationParams>(apiClient) {}
+
+QString CancelPackageInstallationLoader::path(const CancelPackageInstallationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Packages/Installing/") + Support::toString< QString>(params.packageId()) ;
+}
+
+QUrlQuery CancelPackageInstallationLoader::query(const CancelPackageInstallationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CancelPackageInstallationLoader::body(const CancelPackageInstallationParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation CancelPackageInstallationLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 GetRepositoriesLoader::GetRepositoriesLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QList<RepositoryInfo>, GetRepositoriesParams>(apiClient) {}
 
@@ -122,6 +189,35 @@ QByteArray GetRepositoriesLoader::body(const GetRepositoriesParams &params) cons
 QNetworkAccessManager::Operation GetRepositoriesLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+SetRepositoriesLoader::SetRepositoriesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SetRepositoriesParams>(apiClient) {}
+
+QString SetRepositoriesLoader::path(const SetRepositoriesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Repositories");
+}
+
+QUrlQuery SetRepositoriesLoader::query(const SetRepositoriesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SetRepositoriesLoader::body(const SetRepositoriesParams &params) const {
+	return Support::toString<QList<RepositoryInfo>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SetRepositoriesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/playlists.cpp
+++ b/core/src/loader/http/playlists.cpp
@@ -76,6 +76,73 @@ QNetworkAccessManager::Operation CreatePlaylistLoader::operation() const {
 
 }
 
+AddToPlaylistLoader::AddToPlaylistLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, AddToPlaylistParams>(apiClient) {}
+
+QString AddToPlaylistLoader::path(const AddToPlaylistParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Playlists/") + Support::toString< QString>(params.playlistId()) + QStringLiteral("/Items");
+}
+
+QUrlQuery AddToPlaylistLoader::query(const AddToPlaylistParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.idsNull()) {
+		result.addQueryItem("ids", Support::toString<QStringList>(params.ids()));
+	}
+	if (!params.userIdNull()) {
+		result.addQueryItem("userId", Support::toString<QString>(params.userId()));
+	}
+	
+	return result;
+}
+
+QByteArray AddToPlaylistLoader::body(const AddToPlaylistParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation AddToPlaylistLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+RemoveFromPlaylistLoader::RemoveFromPlaylistLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RemoveFromPlaylistParams>(apiClient) {}
+
+QString RemoveFromPlaylistLoader::path(const RemoveFromPlaylistParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Playlists/") + Support::toString< QString>(params.playlistId()) + QStringLiteral("/Items");
+}
+
+QUrlQuery RemoveFromPlaylistLoader::query(const RemoveFromPlaylistParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.entryIdsNull()) {
+		result.addQueryItem("entryIds", Support::toString<QStringList>(params.entryIds()));
+	}
+	
+	return result;
+}
+
+QByteArray RemoveFromPlaylistLoader::body(const RemoveFromPlaylistParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RemoveFromPlaylistLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 GetPlaylistItemsLoader::GetPlaylistItemsLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<BaseItemDtoQueryResult, GetPlaylistItemsParams>(apiClient) {}
 
@@ -124,6 +191,35 @@ QByteArray GetPlaylistItemsLoader::body(const GetPlaylistItemsParams &params) co
 QNetworkAccessManager::Operation GetPlaylistItemsLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+MoveItemLoader::MoveItemLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, MoveItemParams>(apiClient) {}
+
+QString MoveItemLoader::path(const MoveItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Playlists/") + Support::toString< QString>(params.playlistId()) + QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Move/") + Support::toString< qint32>(params.newIndex()) ;
+}
+
+QUrlQuery MoveItemLoader::query(const MoveItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray MoveItemLoader::body(const MoveItemParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation MoveItemLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/playstate.cpp
+++ b/core/src/loader/http/playstate.cpp
@@ -35,6 +35,125 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+ReportPlaybackStartLoader::ReportPlaybackStartLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ReportPlaybackStartParams>(apiClient) {}
+
+QString ReportPlaybackStartLoader::path(const ReportPlaybackStartParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Playing");
+}
+
+QUrlQuery ReportPlaybackStartLoader::query(const ReportPlaybackStartParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ReportPlaybackStartLoader::body(const ReportPlaybackStartParams &params) const {
+	return Support::toString<QSharedPointer<PlaybackStartInfo>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation ReportPlaybackStartLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+PingPlaybackSessionLoader::PingPlaybackSessionLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PingPlaybackSessionParams>(apiClient) {}
+
+QString PingPlaybackSessionLoader::path(const PingPlaybackSessionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Playing/Ping");
+}
+
+QUrlQuery PingPlaybackSessionLoader::query(const PingPlaybackSessionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.playSessionIdNull()) {
+		result.addQueryItem("playSessionId", Support::toString<QString>(params.playSessionId()));
+	}
+	
+	return result;
+}
+
+QByteArray PingPlaybackSessionLoader::body(const PingPlaybackSessionParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PingPlaybackSessionLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+ReportPlaybackProgressLoader::ReportPlaybackProgressLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ReportPlaybackProgressParams>(apiClient) {}
+
+QString ReportPlaybackProgressLoader::path(const ReportPlaybackProgressParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Playing/Progress");
+}
+
+QUrlQuery ReportPlaybackProgressLoader::query(const ReportPlaybackProgressParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ReportPlaybackProgressLoader::body(const ReportPlaybackProgressParams &params) const {
+	return Support::toString<QSharedPointer<PlaybackProgressInfo>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation ReportPlaybackProgressLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+ReportPlaybackStoppedLoader::ReportPlaybackStoppedLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ReportPlaybackStoppedParams>(apiClient) {}
+
+QString ReportPlaybackStoppedLoader::path(const ReportPlaybackStoppedParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Playing/Stopped");
+}
+
+QUrlQuery ReportPlaybackStoppedLoader::query(const ReportPlaybackStoppedParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ReportPlaybackStoppedLoader::body(const ReportPlaybackStoppedParams &params) const {
+	return Support::toString<QSharedPointer<PlaybackStopInfo>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation ReportPlaybackStoppedLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 MarkPlayedItemLoader::MarkPlayedItemLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<UserItemDataDto, MarkPlayedItemParams>(apiClient) {}
 
@@ -93,6 +212,162 @@ QByteArray MarkUnplayedItemLoader::body(const MarkUnplayedItemParams &params) co
 QNetworkAccessManager::Operation MarkUnplayedItemLoader::operation() const {
 	// HTTP method Delete
 	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+OnPlaybackStartLoader::OnPlaybackStartLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, OnPlaybackStartParams>(apiClient) {}
+
+QString OnPlaybackStartLoader::path(const OnPlaybackStartParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/PlayingItems/") + Support::toString< QString>(params.itemId()) ;
+}
+
+QUrlQuery OnPlaybackStartLoader::query(const OnPlaybackStartParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.mediaSourceIdNull()) {
+		result.addQueryItem("mediaSourceId", Support::toString<QString>(params.mediaSourceId()));
+	}
+	if (!params.audioStreamIndexNull()) {
+		result.addQueryItem("audioStreamIndex", Support::toString<std::optional<qint32>>(params.audioStreamIndex()));
+	}
+	if (!params.subtitleStreamIndexNull()) {
+		result.addQueryItem("subtitleStreamIndex", Support::toString<std::optional<qint32>>(params.subtitleStreamIndex()));
+	}
+	if (!params.playMethodNull()) {
+		result.addQueryItem("playMethod", Support::toString<PlayMethod>(params.playMethod()));
+	}
+	if (!params.liveStreamIdNull()) {
+		result.addQueryItem("liveStreamId", Support::toString<QString>(params.liveStreamId()));
+	}
+	if (!params.playSessionIdNull()) {
+		result.addQueryItem("playSessionId", Support::toString<QString>(params.playSessionId()));
+	}
+	if (!params.canSeekNull()) {
+		result.addQueryItem("canSeek", Support::toString<std::optional<bool>>(params.canSeek()));
+	}
+	
+	return result;
+}
+
+QByteArray OnPlaybackStartLoader::body(const OnPlaybackStartParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation OnPlaybackStartLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+OnPlaybackStoppedLoader::OnPlaybackStoppedLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, OnPlaybackStoppedParams>(apiClient) {}
+
+QString OnPlaybackStoppedLoader::path(const OnPlaybackStoppedParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/PlayingItems/") + Support::toString< QString>(params.itemId()) ;
+}
+
+QUrlQuery OnPlaybackStoppedLoader::query(const OnPlaybackStoppedParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.mediaSourceIdNull()) {
+		result.addQueryItem("mediaSourceId", Support::toString<QString>(params.mediaSourceId()));
+	}
+	if (!params.nextMediaTypeNull()) {
+		result.addQueryItem("nextMediaType", Support::toString<QString>(params.nextMediaType()));
+	}
+	if (!params.positionTicksNull()) {
+		result.addQueryItem("positionTicks", Support::toString<std::optional<qint64>>(params.positionTicks()));
+	}
+	if (!params.liveStreamIdNull()) {
+		result.addQueryItem("liveStreamId", Support::toString<QString>(params.liveStreamId()));
+	}
+	if (!params.playSessionIdNull()) {
+		result.addQueryItem("playSessionId", Support::toString<QString>(params.playSessionId()));
+	}
+	
+	return result;
+}
+
+QByteArray OnPlaybackStoppedLoader::body(const OnPlaybackStoppedParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation OnPlaybackStoppedLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+OnPlaybackProgressLoader::OnPlaybackProgressLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, OnPlaybackProgressParams>(apiClient) {}
+
+QString OnPlaybackProgressLoader::path(const OnPlaybackProgressParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/PlayingItems/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Progress");
+}
+
+QUrlQuery OnPlaybackProgressLoader::query(const OnPlaybackProgressParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.mediaSourceIdNull()) {
+		result.addQueryItem("mediaSourceId", Support::toString<QString>(params.mediaSourceId()));
+	}
+	if (!params.positionTicksNull()) {
+		result.addQueryItem("positionTicks", Support::toString<std::optional<qint64>>(params.positionTicks()));
+	}
+	if (!params.audioStreamIndexNull()) {
+		result.addQueryItem("audioStreamIndex", Support::toString<std::optional<qint32>>(params.audioStreamIndex()));
+	}
+	if (!params.subtitleStreamIndexNull()) {
+		result.addQueryItem("subtitleStreamIndex", Support::toString<std::optional<qint32>>(params.subtitleStreamIndex()));
+	}
+	if (!params.volumeLevelNull()) {
+		result.addQueryItem("volumeLevel", Support::toString<std::optional<qint32>>(params.volumeLevel()));
+	}
+	if (!params.playMethodNull()) {
+		result.addQueryItem("playMethod", Support::toString<PlayMethod>(params.playMethod()));
+	}
+	if (!params.liveStreamIdNull()) {
+		result.addQueryItem("liveStreamId", Support::toString<QString>(params.liveStreamId()));
+	}
+	if (!params.playSessionIdNull()) {
+		result.addQueryItem("playSessionId", Support::toString<QString>(params.playSessionId()));
+	}
+	if (!params.repeatModeNull()) {
+		result.addQueryItem("repeatMode", Support::toString<RepeatMode>(params.repeatMode()));
+	}
+	if (!params.isPausedNull()) {
+		result.addQueryItem("isPaused", Support::toString<std::optional<bool>>(params.isPaused()));
+	}
+	if (!params.isMutedNull()) {
+		result.addQueryItem("isMuted", Support::toString<std::optional<bool>>(params.isMuted()));
+	}
+	
+	return result;
+}
+
+QByteArray OnPlaybackProgressLoader::body(const OnPlaybackProgressParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation OnPlaybackProgressLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/plugins.cpp
+++ b/core/src/loader/http/plugins.cpp
@@ -64,6 +64,122 @@ QNetworkAccessManager::Operation GetPluginsLoader::operation() const {
 
 }
 
+UninstallPluginLoader::UninstallPluginLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UninstallPluginParams>(apiClient) {}
+
+QString UninstallPluginLoader::path(const UninstallPluginParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Plugins/") + Support::toString< QString>(params.pluginId()) ;
+}
+
+QUrlQuery UninstallPluginLoader::query(const UninstallPluginParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UninstallPluginLoader::body(const UninstallPluginParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation UninstallPluginLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+UninstallPluginByVersionLoader::UninstallPluginByVersionLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UninstallPluginByVersionParams>(apiClient) {}
+
+QString UninstallPluginByVersionLoader::path(const UninstallPluginByVersionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Plugins/") + Support::toString< QString>(params.pluginId()) + QStringLiteral("/") + Support::toString< QSharedPointer<Version>>(params.version()) ;
+}
+
+QUrlQuery UninstallPluginByVersionLoader::query(const UninstallPluginByVersionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UninstallPluginByVersionLoader::body(const UninstallPluginByVersionParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation UninstallPluginByVersionLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+DisablePluginLoader::DisablePluginLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DisablePluginParams>(apiClient) {}
+
+QString DisablePluginLoader::path(const DisablePluginParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Plugins/") + Support::toString< QString>(params.pluginId()) + QStringLiteral("/") + Support::toString< QSharedPointer<Version>>(params.version()) + QStringLiteral("/Disable");
+}
+
+QUrlQuery DisablePluginLoader::query(const DisablePluginParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DisablePluginLoader::body(const DisablePluginParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DisablePluginLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+EnablePluginLoader::EnablePluginLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, EnablePluginParams>(apiClient) {}
+
+QString EnablePluginLoader::path(const EnablePluginParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Plugins/") + Support::toString< QString>(params.pluginId()) + QStringLiteral("/") + Support::toString< QSharedPointer<Version>>(params.version()) + QStringLiteral("/Enable");
+}
+
+QUrlQuery EnablePluginLoader::query(const EnablePluginParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray EnablePluginLoader::body(const EnablePluginParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation EnablePluginLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetPluginConfigurationLoader::GetPluginConfigurationLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<BasePluginConfiguration, GetPluginConfigurationParams>(apiClient) {}
 
@@ -90,6 +206,93 @@ QByteArray GetPluginConfigurationLoader::body(const GetPluginConfigurationParams
 QNetworkAccessManager::Operation GetPluginConfigurationLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+UpdatePluginConfigurationLoader::UpdatePluginConfigurationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdatePluginConfigurationParams>(apiClient) {}
+
+QString UpdatePluginConfigurationLoader::path(const UpdatePluginConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Plugins/") + Support::toString< QString>(params.pluginId()) + QStringLiteral("/Configuration");
+}
+
+QUrlQuery UpdatePluginConfigurationLoader::query(const UpdatePluginConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdatePluginConfigurationLoader::body(const UpdatePluginConfigurationParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation UpdatePluginConfigurationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+GetPluginManifestLoader::GetPluginManifestLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, GetPluginManifestParams>(apiClient) {}
+
+QString GetPluginManifestLoader::path(const GetPluginManifestParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Plugins/") + Support::toString< QString>(params.pluginId()) + QStringLiteral("/Manifest");
+}
+
+QUrlQuery GetPluginManifestLoader::query(const GetPluginManifestParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray GetPluginManifestLoader::body(const GetPluginManifestParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation GetPluginManifestLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UpdatePluginSecurityInfoLoader::UpdatePluginSecurityInfoLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdatePluginSecurityInfoParams>(apiClient) {}
+
+QString UpdatePluginSecurityInfoLoader::path(const UpdatePluginSecurityInfoParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Plugins/SecurityInfo");
+}
+
+QUrlQuery UpdatePluginSecurityInfoLoader::query(const UpdatePluginSecurityInfoParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdatePluginSecurityInfoLoader::body(const UpdatePluginSecurityInfoParams &params) const {
+	return Support::toString<QSharedPointer<PluginSecurityInfo>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdatePluginSecurityInfoLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/quickconnect.cpp
+++ b/core/src/loader/http/quickconnect.cpp
@@ -35,6 +35,35 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+ActivateLoader::ActivateLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ActivateParams>(apiClient) {}
+
+QString ActivateLoader::path(const ActivateParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/QuickConnect/Activate");
+}
+
+QUrlQuery ActivateLoader::query(const ActivateParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ActivateLoader::body(const ActivateParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation ActivateLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 AuthorizeLoader::AuthorizeLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<bool, AuthorizeParams>(apiClient) {}
 
@@ -60,6 +89,38 @@ QByteArray AuthorizeLoader::body(const AuthorizeParams &params) const {
 }
 
 QNetworkAccessManager::Operation AuthorizeLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+AvailableLoader::AvailableLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, AvailableParams>(apiClient) {}
+
+QString AvailableLoader::path(const AvailableParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/QuickConnect/Available");
+}
+
+QUrlQuery AvailableLoader::query(const AvailableParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.statusNull()) {
+		result.addQueryItem("status", Support::toString<QuickConnectState>(params.status()));
+	}
+	
+	return result;
+}
+
+QByteArray AvailableLoader::body(const AvailableParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation AvailableLoader::operation() const {
 	// HTTP method Post
 	return QNetworkAccessManager::PostOperation;
 

--- a/core/src/loader/http/remoteimage.cpp
+++ b/core/src/loader/http/remoteimage.cpp
@@ -79,6 +79,39 @@ QNetworkAccessManager::Operation GetRemoteImagesLoader::operation() const {
 
 }
 
+DownloadRemoteImageLoader::DownloadRemoteImageLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DownloadRemoteImageParams>(apiClient) {}
+
+QString DownloadRemoteImageLoader::path(const DownloadRemoteImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/RemoteImages/Download");
+}
+
+QUrlQuery DownloadRemoteImageLoader::query(const DownloadRemoteImageParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("type", Support::toString<ImageType>(params.type()));
+
+	// Optional parameters
+	if (!params.imageUrlNull()) {
+		result.addQueryItem("imageUrl", Support::toString<QString>(params.imageUrl()));
+	}
+	
+	return result;
+}
+
+QByteArray DownloadRemoteImageLoader::body(const DownloadRemoteImageParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DownloadRemoteImageLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetRemoteImageProvidersLoader::GetRemoteImageProvidersLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QList<ImageProviderInfo>, GetRemoteImageProvidersParams>(apiClient) {}
 

--- a/core/src/loader/http/scheduledtasks.cpp
+++ b/core/src/loader/http/scheduledtasks.cpp
@@ -99,6 +99,93 @@ QNetworkAccessManager::Operation GetTaskLoader::operation() const {
 
 }
 
+UpdateTaskLoader::UpdateTaskLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateTaskParams>(apiClient) {}
+
+QString UpdateTaskLoader::path(const UpdateTaskParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/ScheduledTasks/") + Support::toString< QString>(params.taskId()) + QStringLiteral("/Triggers");
+}
+
+QUrlQuery UpdateTaskLoader::query(const UpdateTaskParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateTaskLoader::body(const UpdateTaskParams &params) const {
+	return Support::toString<QList<TaskTriggerInfo>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateTaskLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+StartTaskLoader::StartTaskLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, StartTaskParams>(apiClient) {}
+
+QString StartTaskLoader::path(const StartTaskParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/ScheduledTasks/Running/") + Support::toString< QString>(params.taskId()) ;
+}
+
+QUrlQuery StartTaskLoader::query(const StartTaskParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray StartTaskLoader::body(const StartTaskParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation StartTaskLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+StopTaskLoader::StopTaskLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, StopTaskParams>(apiClient) {}
+
+QString StopTaskLoader::path(const StopTaskParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/ScheduledTasks/Running/") + Support::toString< QString>(params.taskId()) ;
+}
+
+QUrlQuery StopTaskLoader::query(const StopTaskParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray StopTaskLoader::body(const StopTaskParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation StopTaskLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/session.cpp
+++ b/core/src/loader/http/session.cpp
@@ -245,6 +245,18 @@ QUrlQuery PlayLoader::query(const PlayParams &params) const {
 	if (!params.startPositionTicksNull()) {
 		result.addQueryItem("startPositionTicks", Support::toString<std::optional<qint64>>(params.startPositionTicks()));
 	}
+	if (!params.mediaSourceIdNull()) {
+		result.addQueryItem("mediaSourceId", Support::toString<QString>(params.mediaSourceId()));
+	}
+	if (!params.audioStreamIndexNull()) {
+		result.addQueryItem("audioStreamIndex", Support::toString<std::optional<qint32>>(params.audioStreamIndex()));
+	}
+	if (!params.subtitleStreamIndexNull()) {
+		result.addQueryItem("subtitleStreamIndex", Support::toString<std::optional<qint32>>(params.subtitleStreamIndex()));
+	}
+	if (!params.startIndexNull()) {
+		result.addQueryItem("startIndex", Support::toString<std::optional<qint32>>(params.startIndex()));
+	}
 	
 	return result;
 }

--- a/core/src/loader/http/session.cpp
+++ b/core/src/loader/http/session.cpp
@@ -131,6 +131,429 @@ QNetworkAccessManager::Operation GetSessionsLoader::operation() const {
 
 }
 
+SendFullGeneralCommandLoader::SendFullGeneralCommandLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SendFullGeneralCommandParams>(apiClient) {}
+
+QString SendFullGeneralCommandLoader::path(const SendFullGeneralCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/Command");
+}
+
+QUrlQuery SendFullGeneralCommandLoader::query(const SendFullGeneralCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SendFullGeneralCommandLoader::body(const SendFullGeneralCommandParams &params) const {
+	return Support::toString<QSharedPointer<GeneralCommand>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SendFullGeneralCommandLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SendGeneralCommandLoader::SendGeneralCommandLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SendGeneralCommandParams>(apiClient) {}
+
+QString SendGeneralCommandLoader::path(const SendGeneralCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/Command/") + Support::toString< GeneralCommandType>(params.command()) ;
+}
+
+QUrlQuery SendGeneralCommandLoader::query(const SendGeneralCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SendGeneralCommandLoader::body(const SendGeneralCommandParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SendGeneralCommandLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SendMessageCommandLoader::SendMessageCommandLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SendMessageCommandParams>(apiClient) {}
+
+QString SendMessageCommandLoader::path(const SendMessageCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/Message");
+}
+
+QUrlQuery SendMessageCommandLoader::query(const SendMessageCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("text", Support::toString<QString>(params.text()));
+
+	// Optional parameters
+	if (!params.headerNull()) {
+		result.addQueryItem("header", Support::toString<QString>(params.header()));
+	}
+	if (!params.timeoutMsNull()) {
+		result.addQueryItem("timeoutMs", Support::toString<std::optional<qint64>>(params.timeoutMs()));
+	}
+	
+	return result;
+}
+
+QByteArray SendMessageCommandLoader::body(const SendMessageCommandParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SendMessageCommandLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+PlayLoader::PlayLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PlayParams>(apiClient) {}
+
+QString PlayLoader::path(const PlayParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/Playing");
+}
+
+QUrlQuery PlayLoader::query(const PlayParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("playCommand", Support::toString<PlayCommand>(params.playCommand()));
+	result.addQueryItem("itemIds", Support::toString<QStringList>(params.itemIds()));
+
+	// Optional parameters
+	if (!params.startPositionTicksNull()) {
+		result.addQueryItem("startPositionTicks", Support::toString<std::optional<qint64>>(params.startPositionTicks()));
+	}
+	
+	return result;
+}
+
+QByteArray PlayLoader::body(const PlayParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PlayLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SendPlaystateCommandLoader::SendPlaystateCommandLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SendPlaystateCommandParams>(apiClient) {}
+
+QString SendPlaystateCommandLoader::path(const SendPlaystateCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/Playing/") + Support::toString< PlaystateCommand>(params.command()) ;
+}
+
+QUrlQuery SendPlaystateCommandLoader::query(const SendPlaystateCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.seekPositionTicksNull()) {
+		result.addQueryItem("seekPositionTicks", Support::toString<std::optional<qint64>>(params.seekPositionTicks()));
+	}
+	if (!params.controllingUserIdNull()) {
+		result.addQueryItem("controllingUserId", Support::toString<QString>(params.controllingUserId()));
+	}
+	
+	return result;
+}
+
+QByteArray SendPlaystateCommandLoader::body(const SendPlaystateCommandParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SendPlaystateCommandLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SendSystemCommandLoader::SendSystemCommandLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SendSystemCommandParams>(apiClient) {}
+
+QString SendSystemCommandLoader::path(const SendSystemCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/System/") + Support::toString< GeneralCommandType>(params.command()) ;
+}
+
+QUrlQuery SendSystemCommandLoader::query(const SendSystemCommandParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SendSystemCommandLoader::body(const SendSystemCommandParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SendSystemCommandLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+AddUserToSessionLoader::AddUserToSessionLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, AddUserToSessionParams>(apiClient) {}
+
+QString AddUserToSessionLoader::path(const AddUserToSessionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/User/") + Support::toString< QString>(params.userId()) ;
+}
+
+QUrlQuery AddUserToSessionLoader::query(const AddUserToSessionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray AddUserToSessionLoader::body(const AddUserToSessionParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation AddUserToSessionLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+RemoveUserFromSessionLoader::RemoveUserFromSessionLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RemoveUserFromSessionParams>(apiClient) {}
+
+QString RemoveUserFromSessionLoader::path(const RemoveUserFromSessionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/User/") + Support::toString< QString>(params.userId()) ;
+}
+
+QUrlQuery RemoveUserFromSessionLoader::query(const RemoveUserFromSessionParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray RemoveUserFromSessionLoader::body(const RemoveUserFromSessionParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RemoveUserFromSessionLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+DisplayContentLoader::DisplayContentLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DisplayContentParams>(apiClient) {}
+
+QString DisplayContentLoader::path(const DisplayContentParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/") + Support::toString< QString>(params.sessionId()) + QStringLiteral("/Viewing");
+}
+
+QUrlQuery DisplayContentLoader::query(const DisplayContentParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("itemType", Support::toString<QString>(params.itemType()));
+	result.addQueryItem("itemId", Support::toString<QString>(params.itemId()));
+	result.addQueryItem("itemName", Support::toString<QString>(params.itemName()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DisplayContentLoader::body(const DisplayContentParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DisplayContentLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+PostCapabilitiesLoader::PostCapabilitiesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostCapabilitiesParams>(apiClient) {}
+
+QString PostCapabilitiesLoader::path(const PostCapabilitiesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Capabilities");
+}
+
+QUrlQuery PostCapabilitiesLoader::query(const PostCapabilitiesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.jellyfinIdNull()) {
+		result.addQueryItem("id", Support::toString<QString>(params.jellyfinId()));
+	}
+	if (!params.playableMediaTypesNull()) {
+		result.addQueryItem("playableMediaTypes", Support::toString<QStringList>(params.playableMediaTypes()));
+	}
+	if (!params.supportedCommandsNull()) {
+		result.addQueryItem("supportedCommands", Support::toString<QList<GeneralCommandType>>(params.supportedCommands()));
+	}
+	if (!params.supportsMediaControlNull()) {
+		result.addQueryItem("supportsMediaControl", Support::toString<std::optional<bool>>(params.supportsMediaControl()));
+	}
+	if (!params.supportsSyncNull()) {
+		result.addQueryItem("supportsSync", Support::toString<std::optional<bool>>(params.supportsSync()));
+	}
+	if (!params.supportsPersistentIdentifierNull()) {
+		result.addQueryItem("supportsPersistentIdentifier", Support::toString<std::optional<bool>>(params.supportsPersistentIdentifier()));
+	}
+	
+	return result;
+}
+
+QByteArray PostCapabilitiesLoader::body(const PostCapabilitiesParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation PostCapabilitiesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+PostFullCapabilitiesLoader::PostFullCapabilitiesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, PostFullCapabilitiesParams>(apiClient) {}
+
+QString PostFullCapabilitiesLoader::path(const PostFullCapabilitiesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Capabilities/Full");
+}
+
+QUrlQuery PostFullCapabilitiesLoader::query(const PostFullCapabilitiesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	if (!params.jellyfinIdNull()) {
+		result.addQueryItem("id", Support::toString<QString>(params.jellyfinId()));
+	}
+	
+	return result;
+}
+
+QByteArray PostFullCapabilitiesLoader::body(const PostFullCapabilitiesParams &params) const {
+	return Support::toString<QSharedPointer<ClientCapabilitiesDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation PostFullCapabilitiesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+ReportSessionEndedLoader::ReportSessionEndedLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ReportSessionEndedParams>(apiClient) {}
+
+QString ReportSessionEndedLoader::path(const ReportSessionEndedParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Logout");
+}
+
+QUrlQuery ReportSessionEndedLoader::query(const ReportSessionEndedParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ReportSessionEndedLoader::body(const ReportSessionEndedParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation ReportSessionEndedLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+ReportViewingLoader::ReportViewingLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ReportViewingParams>(apiClient) {}
+
+QString ReportViewingLoader::path(const ReportViewingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Sessions/Viewing");
+}
+
+QUrlQuery ReportViewingLoader::query(const ReportViewingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("itemId", Support::toString<QString>(params.itemId()));
+
+	// Optional parameters
+	if (!params.sessionIdNull()) {
+		result.addQueryItem("sessionId", Support::toString<QString>(params.sessionId()));
+	}
+	
+	return result;
+}
+
+QByteArray ReportViewingLoader::body(const ReportViewingParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation ReportViewingLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/startup.cpp
+++ b/core/src/loader/http/startup.cpp
@@ -35,6 +35,35 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+CompleteWizardLoader::CompleteWizardLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, CompleteWizardParams>(apiClient) {}
+
+QString CompleteWizardLoader::path(const CompleteWizardParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Startup/Complete");
+}
+
+QUrlQuery CompleteWizardLoader::query(const CompleteWizardParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray CompleteWizardLoader::body(const CompleteWizardParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation CompleteWizardLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetStartupConfigurationLoader::GetStartupConfigurationLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<StartupConfigurationDto, GetStartupConfigurationParams>(apiClient) {}
 
@@ -61,6 +90,35 @@ QByteArray GetStartupConfigurationLoader::body(const GetStartupConfigurationPara
 QNetworkAccessManager::Operation GetStartupConfigurationLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+UpdateInitialConfigurationLoader::UpdateInitialConfigurationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateInitialConfigurationParams>(apiClient) {}
+
+QString UpdateInitialConfigurationLoader::path(const UpdateInitialConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Startup/Configuration");
+}
+
+QUrlQuery UpdateInitialConfigurationLoader::query(const UpdateInitialConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateInitialConfigurationLoader::body(const UpdateInitialConfigurationParams &params) const {
+	return Support::toString<QSharedPointer<StartupConfigurationDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateInitialConfigurationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 
@@ -93,6 +151,35 @@ QNetworkAccessManager::Operation GetFirstUser_2Loader::operation() const {
 
 }
 
+SetRemoteAccessLoader::SetRemoteAccessLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SetRemoteAccessParams>(apiClient) {}
+
+QString SetRemoteAccessLoader::path(const SetRemoteAccessParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Startup/RemoteAccess");
+}
+
+QUrlQuery SetRemoteAccessLoader::query(const SetRemoteAccessParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SetRemoteAccessLoader::body(const SetRemoteAccessParams &params) const {
+	return Support::toString<QSharedPointer<StartupRemoteAccessDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SetRemoteAccessLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetFirstUserLoader::GetFirstUserLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<StartupUserDto, GetFirstUserParams>(apiClient) {}
 
@@ -119,6 +206,35 @@ QByteArray GetFirstUserLoader::body(const GetFirstUserParams &params) const {
 QNetworkAccessManager::Operation GetFirstUserLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+UpdateStartupUserLoader::UpdateStartupUserLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateStartupUserParams>(apiClient) {}
+
+QString UpdateStartupUserLoader::path(const UpdateStartupUserParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Startup/User");
+}
+
+QUrlQuery UpdateStartupUserLoader::query(const UpdateStartupUserParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateStartupUserLoader::body(const UpdateStartupUserParams &params) const {
+	return Support::toString<QSharedPointer<StartupUserDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateStartupUserLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/subtitle.cpp
+++ b/core/src/loader/http/subtitle.cpp
@@ -96,6 +96,93 @@ QNetworkAccessManager::Operation SearchRemoteSubtitlesLoader::operation() const 
 
 }
 
+DownloadRemoteSubtitlesLoader::DownloadRemoteSubtitlesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DownloadRemoteSubtitlesParams>(apiClient) {}
+
+QString DownloadRemoteSubtitlesLoader::path(const DownloadRemoteSubtitlesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Items/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/RemoteSearch/Subtitles/") + Support::toString< QString>(params.subtitleId()) ;
+}
+
+QUrlQuery DownloadRemoteSubtitlesLoader::query(const DownloadRemoteSubtitlesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DownloadRemoteSubtitlesLoader::body(const DownloadRemoteSubtitlesParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DownloadRemoteSubtitlesLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UploadSubtitleLoader::UploadSubtitleLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UploadSubtitleParams>(apiClient) {}
+
+QString UploadSubtitleLoader::path(const UploadSubtitleParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Videos/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Subtitles");
+}
+
+QUrlQuery UploadSubtitleLoader::query(const UploadSubtitleParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UploadSubtitleLoader::body(const UploadSubtitleParams &params) const {
+	return Support::toString<QSharedPointer<UploadSubtitleDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UploadSubtitleLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+DeleteSubtitleLoader::DeleteSubtitleLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteSubtitleParams>(apiClient) {}
+
+QString DeleteSubtitleLoader::path(const DeleteSubtitleParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Videos/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/Subtitles/") + Support::toString< qint32>(params.index()) ;
+}
+
+QUrlQuery DeleteSubtitleLoader::query(const DeleteSubtitleParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteSubtitleLoader::body(const DeleteSubtitleParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteSubtitleLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/http/syncplay.cpp
+++ b/core/src/loader/http/syncplay.cpp
@@ -35,6 +35,93 @@ namespace HTTP {
 
 using namespace Jellyfin::DTO;
 
+SyncPlayBufferingLoader::SyncPlayBufferingLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayBufferingParams>(apiClient) {}
+
+QString SyncPlayBufferingLoader::path(const SyncPlayBufferingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Buffering");
+}
+
+QUrlQuery SyncPlayBufferingLoader::query(const SyncPlayBufferingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayBufferingLoader::body(const SyncPlayBufferingParams &params) const {
+	return Support::toString<QSharedPointer<BufferRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayBufferingLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayJoinGroupLoader::SyncPlayJoinGroupLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayJoinGroupParams>(apiClient) {}
+
+QString SyncPlayJoinGroupLoader::path(const SyncPlayJoinGroupParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Join");
+}
+
+QUrlQuery SyncPlayJoinGroupLoader::query(const SyncPlayJoinGroupParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayJoinGroupLoader::body(const SyncPlayJoinGroupParams &params) const {
+	return Support::toString<QSharedPointer<JoinGroupRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayJoinGroupLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayLeaveGroupLoader::SyncPlayLeaveGroupLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayLeaveGroupParams>(apiClient) {}
+
+QString SyncPlayLeaveGroupLoader::path(const SyncPlayLeaveGroupParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Leave");
+}
+
+QUrlQuery SyncPlayLeaveGroupLoader::query(const SyncPlayLeaveGroupParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayLeaveGroupLoader::body(const SyncPlayLeaveGroupParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SyncPlayLeaveGroupLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 SyncPlayGetGroupsLoader::SyncPlayGetGroupsLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QList<GroupInfoDto>, SyncPlayGetGroupsParams>(apiClient) {}
 
@@ -61,6 +148,499 @@ QByteArray SyncPlayGetGroupsLoader::body(const SyncPlayGetGroupsParams &params) 
 QNetworkAccessManager::Operation SyncPlayGetGroupsLoader::operation() const {
 	// HTTP method Get
 	return QNetworkAccessManager::GetOperation;
+
+}
+
+SyncPlayMovePlaylistItemLoader::SyncPlayMovePlaylistItemLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayMovePlaylistItemParams>(apiClient) {}
+
+QString SyncPlayMovePlaylistItemLoader::path(const SyncPlayMovePlaylistItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/MovePlaylistItem");
+}
+
+QUrlQuery SyncPlayMovePlaylistItemLoader::query(const SyncPlayMovePlaylistItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayMovePlaylistItemLoader::body(const SyncPlayMovePlaylistItemParams &params) const {
+	return Support::toString<QSharedPointer<MovePlaylistItemRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayMovePlaylistItemLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayCreateGroupLoader::SyncPlayCreateGroupLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayCreateGroupParams>(apiClient) {}
+
+QString SyncPlayCreateGroupLoader::path(const SyncPlayCreateGroupParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/New");
+}
+
+QUrlQuery SyncPlayCreateGroupLoader::query(const SyncPlayCreateGroupParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayCreateGroupLoader::body(const SyncPlayCreateGroupParams &params) const {
+	return Support::toString<QSharedPointer<NewGroupRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayCreateGroupLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayNextItemLoader::SyncPlayNextItemLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayNextItemParams>(apiClient) {}
+
+QString SyncPlayNextItemLoader::path(const SyncPlayNextItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/NextItem");
+}
+
+QUrlQuery SyncPlayNextItemLoader::query(const SyncPlayNextItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayNextItemLoader::body(const SyncPlayNextItemParams &params) const {
+	return Support::toString<QSharedPointer<NextItemRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayNextItemLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayPauseLoader::SyncPlayPauseLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayPauseParams>(apiClient) {}
+
+QString SyncPlayPauseLoader::path(const SyncPlayPauseParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Pause");
+}
+
+QUrlQuery SyncPlayPauseLoader::query(const SyncPlayPauseParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayPauseLoader::body(const SyncPlayPauseParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SyncPlayPauseLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayPingLoader::SyncPlayPingLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayPingParams>(apiClient) {}
+
+QString SyncPlayPingLoader::path(const SyncPlayPingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Ping");
+}
+
+QUrlQuery SyncPlayPingLoader::query(const SyncPlayPingParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayPingLoader::body(const SyncPlayPingParams &params) const {
+	return Support::toString<QSharedPointer<PingRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayPingLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayPreviousItemLoader::SyncPlayPreviousItemLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayPreviousItemParams>(apiClient) {}
+
+QString SyncPlayPreviousItemLoader::path(const SyncPlayPreviousItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/PreviousItem");
+}
+
+QUrlQuery SyncPlayPreviousItemLoader::query(const SyncPlayPreviousItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayPreviousItemLoader::body(const SyncPlayPreviousItemParams &params) const {
+	return Support::toString<QSharedPointer<PreviousItemRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayPreviousItemLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayQueueLoader::SyncPlayQueueLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayQueueParams>(apiClient) {}
+
+QString SyncPlayQueueLoader::path(const SyncPlayQueueParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Queue");
+}
+
+QUrlQuery SyncPlayQueueLoader::query(const SyncPlayQueueParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayQueueLoader::body(const SyncPlayQueueParams &params) const {
+	return Support::toString<QSharedPointer<QueueRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayQueueLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayReadyLoader::SyncPlayReadyLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayReadyParams>(apiClient) {}
+
+QString SyncPlayReadyLoader::path(const SyncPlayReadyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Ready");
+}
+
+QUrlQuery SyncPlayReadyLoader::query(const SyncPlayReadyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayReadyLoader::body(const SyncPlayReadyParams &params) const {
+	return Support::toString<QSharedPointer<ReadyRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayReadyLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayRemoveFromPlaylistLoader::SyncPlayRemoveFromPlaylistLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayRemoveFromPlaylistParams>(apiClient) {}
+
+QString SyncPlayRemoveFromPlaylistLoader::path(const SyncPlayRemoveFromPlaylistParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/RemoveFromPlaylist");
+}
+
+QUrlQuery SyncPlayRemoveFromPlaylistLoader::query(const SyncPlayRemoveFromPlaylistParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayRemoveFromPlaylistLoader::body(const SyncPlayRemoveFromPlaylistParams &params) const {
+	return Support::toString<QSharedPointer<RemoveFromPlaylistRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlayRemoveFromPlaylistLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlaySeekLoader::SyncPlaySeekLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlaySeekParams>(apiClient) {}
+
+QString SyncPlaySeekLoader::path(const SyncPlaySeekParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Seek");
+}
+
+QUrlQuery SyncPlaySeekLoader::query(const SyncPlaySeekParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlaySeekLoader::body(const SyncPlaySeekParams &params) const {
+	return Support::toString<QSharedPointer<SeekRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlaySeekLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlaySetIgnoreWaitLoader::SyncPlaySetIgnoreWaitLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlaySetIgnoreWaitParams>(apiClient) {}
+
+QString SyncPlaySetIgnoreWaitLoader::path(const SyncPlaySetIgnoreWaitParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/SetIgnoreWait");
+}
+
+QUrlQuery SyncPlaySetIgnoreWaitLoader::query(const SyncPlaySetIgnoreWaitParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlaySetIgnoreWaitLoader::body(const SyncPlaySetIgnoreWaitParams &params) const {
+	return Support::toString<QSharedPointer<IgnoreWaitRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlaySetIgnoreWaitLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlaySetNewQueueLoader::SyncPlaySetNewQueueLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlaySetNewQueueParams>(apiClient) {}
+
+QString SyncPlaySetNewQueueLoader::path(const SyncPlaySetNewQueueParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/SetNewQueue");
+}
+
+QUrlQuery SyncPlaySetNewQueueLoader::query(const SyncPlaySetNewQueueParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlaySetNewQueueLoader::body(const SyncPlaySetNewQueueParams &params) const {
+	return Support::toString<QSharedPointer<PlayRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlaySetNewQueueLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlaySetPlaylistItemLoader::SyncPlaySetPlaylistItemLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlaySetPlaylistItemParams>(apiClient) {}
+
+QString SyncPlaySetPlaylistItemLoader::path(const SyncPlaySetPlaylistItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/SetPlaylistItem");
+}
+
+QUrlQuery SyncPlaySetPlaylistItemLoader::query(const SyncPlaySetPlaylistItemParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlaySetPlaylistItemLoader::body(const SyncPlaySetPlaylistItemParams &params) const {
+	return Support::toString<QSharedPointer<SetPlaylistItemRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlaySetPlaylistItemLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlaySetRepeatModeLoader::SyncPlaySetRepeatModeLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlaySetRepeatModeParams>(apiClient) {}
+
+QString SyncPlaySetRepeatModeLoader::path(const SyncPlaySetRepeatModeParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/SetRepeatMode");
+}
+
+QUrlQuery SyncPlaySetRepeatModeLoader::query(const SyncPlaySetRepeatModeParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlaySetRepeatModeLoader::body(const SyncPlaySetRepeatModeParams &params) const {
+	return Support::toString<QSharedPointer<SetRepeatModeRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlaySetRepeatModeLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlaySetShuffleModeLoader::SyncPlaySetShuffleModeLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlaySetShuffleModeParams>(apiClient) {}
+
+QString SyncPlaySetShuffleModeLoader::path(const SyncPlaySetShuffleModeParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/SetShuffleMode");
+}
+
+QUrlQuery SyncPlaySetShuffleModeLoader::query(const SyncPlaySetShuffleModeParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlaySetShuffleModeLoader::body(const SyncPlaySetShuffleModeParams &params) const {
+	return Support::toString<QSharedPointer<SetShuffleModeRequestDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation SyncPlaySetShuffleModeLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayStopLoader::SyncPlayStopLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayStopParams>(apiClient) {}
+
+QString SyncPlayStopLoader::path(const SyncPlayStopParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Stop");
+}
+
+QUrlQuery SyncPlayStopLoader::query(const SyncPlayStopParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayStopLoader::body(const SyncPlayStopParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SyncPlayStopLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+SyncPlayUnpauseLoader::SyncPlayUnpauseLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, SyncPlayUnpauseParams>(apiClient) {}
+
+QString SyncPlayUnpauseLoader::path(const SyncPlayUnpauseParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/SyncPlay/Unpause");
+}
+
+QUrlQuery SyncPlayUnpauseLoader::query(const SyncPlayUnpauseParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray SyncPlayUnpauseLoader::body(const SyncPlayUnpauseParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation SyncPlayUnpauseLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
 
 }
 

--- a/core/src/loader/http/system.cpp
+++ b/core/src/loader/http/system.cpp
@@ -209,6 +209,64 @@ QNetworkAccessManager::Operation PostPingSystemLoader::operation() const {
 
 }
 
+RestartApplicationLoader::RestartApplicationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, RestartApplicationParams>(apiClient) {}
+
+QString RestartApplicationLoader::path(const RestartApplicationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/System/Restart");
+}
+
+QUrlQuery RestartApplicationLoader::query(const RestartApplicationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray RestartApplicationLoader::body(const RestartApplicationParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation RestartApplicationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+ShutdownApplicationLoader::ShutdownApplicationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, ShutdownApplicationParams>(apiClient) {}
+
+QString ShutdownApplicationLoader::path(const ShutdownApplicationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/System/Shutdown");
+}
+
+QUrlQuery ShutdownApplicationLoader::query(const ShutdownApplicationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray ShutdownApplicationLoader::body(const ShutdownApplicationParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation ShutdownApplicationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 GetWakeOnLanInfoLoader::GetWakeOnLanInfoLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<QList<WakeOnLanInfo>, GetWakeOnLanInfoParams>(apiClient) {}
 

--- a/core/src/loader/http/user.cpp
+++ b/core/src/loader/http/user.cpp
@@ -99,6 +99,64 @@ QNetworkAccessManager::Operation GetUserByIdLoader::operation() const {
 
 }
 
+DeleteUserLoader::DeleteUserLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteUserParams>(apiClient) {}
+
+QString DeleteUserLoader::path(const DeleteUserParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) ;
+}
+
+QUrlQuery DeleteUserLoader::query(const DeleteUserParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteUserLoader::body(const DeleteUserParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteUserLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+UpdateUserLoader::UpdateUserLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateUserParams>(apiClient) {}
+
+QString UpdateUserLoader::path(const UpdateUserParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) ;
+}
+
+QUrlQuery UpdateUserLoader::query(const UpdateUserParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateUserLoader::body(const UpdateUserParams &params) const {
+	return Support::toString<QSharedPointer<UserDto>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateUserLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 AuthenticateUserLoader::AuthenticateUserLoader(ApiClient *apiClient)
 	: Jellyfin::Support::HttpLoader<AuthenticationResult, AuthenticateUserParams>(apiClient) {}
 
@@ -127,6 +185,122 @@ QByteArray AuthenticateUserLoader::body(const AuthenticateUserParams &params) co
 }
 
 QNetworkAccessManager::Operation AuthenticateUserLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UpdateUserConfigurationLoader::UpdateUserConfigurationLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateUserConfigurationParams>(apiClient) {}
+
+QString UpdateUserConfigurationLoader::path(const UpdateUserConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Configuration");
+}
+
+QUrlQuery UpdateUserConfigurationLoader::query(const UpdateUserConfigurationParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateUserConfigurationLoader::body(const UpdateUserConfigurationParams &params) const {
+	return Support::toString<QSharedPointer<UserConfiguration>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateUserConfigurationLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UpdateUserEasyPasswordLoader::UpdateUserEasyPasswordLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateUserEasyPasswordParams>(apiClient) {}
+
+QString UpdateUserEasyPasswordLoader::path(const UpdateUserEasyPasswordParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/EasyPassword");
+}
+
+QUrlQuery UpdateUserEasyPasswordLoader::query(const UpdateUserEasyPasswordParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateUserEasyPasswordLoader::body(const UpdateUserEasyPasswordParams &params) const {
+	return Support::toString<QSharedPointer<UpdateUserEasyPassword>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateUserEasyPasswordLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UpdateUserPasswordLoader::UpdateUserPasswordLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateUserPasswordParams>(apiClient) {}
+
+QString UpdateUserPasswordLoader::path(const UpdateUserPasswordParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Password");
+}
+
+QUrlQuery UpdateUserPasswordLoader::query(const UpdateUserPasswordParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateUserPasswordLoader::body(const UpdateUserPasswordParams &params) const {
+	return Support::toString<QSharedPointer<UpdateUserPassword>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateUserPasswordLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
+UpdateUserPolicyLoader::UpdateUserPolicyLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, UpdateUserPolicyParams>(apiClient) {}
+
+QString UpdateUserPolicyLoader::path(const UpdateUserPolicyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Users/") + Support::toString< QString>(params.userId()) + QStringLiteral("/Policy");
+}
+
+QUrlQuery UpdateUserPolicyLoader::query(const UpdateUserPolicyParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray UpdateUserPolicyLoader::body(const UpdateUserPolicyParams &params) const {
+	return Support::toString<QSharedPointer<UserPolicy>>(params.body()).toUtf8();
+}
+
+QNetworkAccessManager::Operation UpdateUserPolicyLoader::operation() const {
 	// HTTP method Post
 	return QNetworkAccessManager::PostOperation;
 

--- a/core/src/loader/http/videos.cpp
+++ b/core/src/loader/http/videos.cpp
@@ -67,6 +67,65 @@ QNetworkAccessManager::Operation GetAdditionalPartLoader::operation() const {
 
 }
 
+DeleteAlternateSourcesLoader::DeleteAlternateSourcesLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, DeleteAlternateSourcesParams>(apiClient) {}
+
+QString DeleteAlternateSourcesLoader::path(const DeleteAlternateSourcesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Videos/") + Support::toString< QString>(params.itemId()) + QStringLiteral("/AlternateSources");
+}
+
+QUrlQuery DeleteAlternateSourcesLoader::query(const DeleteAlternateSourcesParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray DeleteAlternateSourcesLoader::body(const DeleteAlternateSourcesParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation DeleteAlternateSourcesLoader::operation() const {
+	// HTTP method Delete
+	return QNetworkAccessManager::DeleteOperation;
+
+}
+
+MergeVersionsLoader::MergeVersionsLoader(ApiClient *apiClient)
+	: Jellyfin::Support::HttpLoader<void, MergeVersionsParams>(apiClient) {}
+
+QString MergeVersionsLoader::path(const MergeVersionsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+	
+	return QStringLiteral("/Videos/MergeVersions");
+}
+
+QUrlQuery MergeVersionsLoader::query(const MergeVersionsParams &params) const {
+	Q_UNUSED(params) // Might be overzealous, but I don't like theses kind of warnings
+
+	QUrlQuery result;
+	result.addQueryItem("ids", Support::toString<QStringList>(params.ids()));
+
+	// Optional parameters
+	
+	return result;
+}
+
+QByteArray MergeVersionsLoader::body(const MergeVersionsParams &params) const {
+	return QByteArray();
+}
+
+QNetworkAccessManager::Operation MergeVersionsLoader::operation() const {
+	// HTTP method Post
+	return QNetworkAccessManager::PostOperation;
+
+}
+
 
 } // NS HTTP
 } // NS Loader

--- a/core/src/loader/requesttypes.cpp
+++ b/core/src/loader/requesttypes.cpp
@@ -47966,6 +47966,69 @@ void PlayParams::setPlayCommand(PlayCommand newPlayCommand) {
 }
 
 
+const qint32 &PlayParams::audioStreamIndex() const {
+	return m_audioStreamIndex.value();
+}
+
+void PlayParams::setAudioStreamIndex(qint32 newAudioStreamIndex)  {
+	m_audioStreamIndex = newAudioStreamIndex;
+}
+
+bool PlayParams::audioStreamIndexNull() const {
+	// Nullable: true
+	// Type Nullable: false
+	
+
+	return !m_audioStreamIndex.has_value();
+}
+
+void PlayParams::setAudioStreamIndexNull() {
+	m_audioStreamIndex = std::nullopt;
+}
+
+
+const QString &PlayParams::mediaSourceId() const {
+	return m_mediaSourceId;
+}
+
+void PlayParams::setMediaSourceId(QString newMediaSourceId)  {
+	m_mediaSourceId = newMediaSourceId;
+}
+
+bool PlayParams::mediaSourceIdNull() const {
+	// Nullable: true
+	// Type Nullable: true
+	
+
+	return m_mediaSourceId.isNull();
+}
+
+void PlayParams::setMediaSourceIdNull() {
+	m_mediaSourceId.clear();
+}
+
+
+const qint32 &PlayParams::startIndex() const {
+	return m_startIndex.value();
+}
+
+void PlayParams::setStartIndex(qint32 newStartIndex)  {
+	m_startIndex = newStartIndex;
+}
+
+bool PlayParams::startIndexNull() const {
+	// Nullable: true
+	// Type Nullable: false
+	
+
+	return !m_startIndex.has_value();
+}
+
+void PlayParams::setStartIndexNull() {
+	m_startIndex = std::nullopt;
+}
+
+
 const qint64 &PlayParams::startPositionTicks() const {
 	return m_startPositionTicks.value();
 }
@@ -47984,6 +48047,27 @@ bool PlayParams::startPositionTicksNull() const {
 
 void PlayParams::setStartPositionTicksNull() {
 	m_startPositionTicks = std::nullopt;
+}
+
+
+const qint32 &PlayParams::subtitleStreamIndex() const {
+	return m_subtitleStreamIndex.value();
+}
+
+void PlayParams::setSubtitleStreamIndex(qint32 newSubtitleStreamIndex)  {
+	m_subtitleStreamIndex = newSubtitleStreamIndex;
+}
+
+bool PlayParams::subtitleStreamIndexNull() const {
+	// Nullable: true
+	// Type Nullable: false
+	
+
+	return !m_subtitleStreamIndex.has_value();
+}
+
+void PlayParams::setSubtitleStreamIndexNull() {
+	m_subtitleStreamIndex = std::nullopt;
 }
 
 

--- a/core/src/model/controllablesession.cpp
+++ b/core/src/model/controllablesession.cpp
@@ -1,0 +1,132 @@
+#include "JellyfinQt/model/controllablesession.h"
+
+#include <optional>
+
+#include "JellyfinQt/loader/http/session.h"
+#include "JellyfinQt/loader/requesttypes.h"
+#include <JellyfinQt/model/playbackmanager.h>
+
+
+namespace Jellyfin {
+namespace Model {
+
+ControllableSession::ControllableSession(QObject *parent)
+    : QObject(parent) {}
+
+// LocalSession
+LocalSession::LocalSession(ApiClient &apiClient, QObject *parent)
+    : ControllableSession(parent), m_apiClient(apiClient) {}
+
+QString LocalSession::id() const {
+    return m_apiClient.deviceId();
+}
+
+QString LocalSession::appName() const {
+    return m_apiClient.appName();
+}
+
+QString LocalSession::name() const {
+    //: Shown in a list of devices to indicate that media should be played on this device
+    return tr("This device");
+}
+
+DeviceType LocalSession::deviceType() const {
+    return DeviceType::Unknown;
+}
+
+QString LocalSession::userName() const {
+    return m_apiClient.userId();
+}
+
+PlaybackManager *LocalSession::createPlaybackManager() const {
+    return new LocalPlaybackManager();
+}
+
+// ControllableJellyfinSession
+ControllableJellyfinSession::ControllableJellyfinSession(const QSharedPointer<DTO::SessionInfo> info, QObject *parent)
+    : ControllableSession(parent),
+      m_data(info) {}
+
+QString ControllableJellyfinSession::id() const {
+    return m_data->jellyfinId();
+}
+
+QString ControllableJellyfinSession::appName() const {
+    return m_data->client();
+}
+
+QString ControllableJellyfinSession::name() const {
+    return m_data->deviceName();
+}
+
+DeviceType ControllableJellyfinSession::deviceType() const {
+    return DeviceType::Unknown;
+}
+
+QString ControllableJellyfinSession::userName() const {
+    return m_data->userName();
+}
+
+PlaybackManager * ControllableJellyfinSession::createPlaybackManager() const {
+    // TODO: implement
+    return nullptr;
+}
+
+RemoteSessionScanner::RemoteSessionScanner(QObject *parent)
+    : QObject(parent) {}
+
+using GetSessionsLoader = Loader::HTTP::GetSessionsLoader;
+class RemoteJellyfinSessionScannerPrivate {
+public:
+    RemoteJellyfinSessionScannerPrivate(ApiClient *apiClient)
+        : apiClient(apiClient) {
+    };
+
+    ApiClient *apiClient;
+    GetSessionsLoader *loader = nullptr;
+};
+
+
+RemoteJellyfinSessionScanner::RemoteJellyfinSessionScanner(ApiClient *apiClient, QObject *parent)
+    : RemoteSessionScanner(parent),
+      d_ptr(new RemoteJellyfinSessionScannerPrivate(apiClient)) {
+}
+
+RemoteJellyfinSessionScanner::~RemoteJellyfinSessionScanner() {}
+
+void RemoteJellyfinSessionScanner::startScanning() {
+    Q_D(RemoteJellyfinSessionScanner);
+    if (d->loader != nullptr) return;
+
+    emit resetSessions();
+    emit sessionFound(new LocalSession(*d->apiClient));
+
+    Loader::GetSessionsParams params;
+    params.setControllableByUserId(d->apiClient->userId());
+    d->loader = new GetSessionsLoader(d->apiClient);
+    d->loader->setParameters(params);
+    connect(d->loader, &Loader::HTTP::GetSessionsLoader::ready, this, [this, d]() {
+        if (d->loader == nullptr) return;
+        QList<DTO::SessionInfo> sessions = d->loader->result();
+
+        for(auto it = sessions.begin(); it != sessions.end(); it++) {
+
+            // Skip this device
+            if (it->jellyfinId() == d->apiClient->deviceId()) continue;
+
+            emit sessionFound(new ControllableJellyfinSession(QSharedPointer<DTO::SessionInfo>::create(*it)));
+        }
+    });
+    d->loader->load();
+}
+
+void RemoteJellyfinSessionScanner::stopScanning() {
+    Q_D(RemoteJellyfinSessionScanner);
+    if (d->loader != nullptr) {
+        d->loader->deleteLater();
+        d->loader = nullptr;
+    }
+}
+
+} // NS Model
+} // NS Jellyfin

--- a/core/src/model/item.cpp
+++ b/core/src/model/item.cpp
@@ -41,8 +41,8 @@ Item::Item(ApiClient *apiClient, QObject *parent)
 }
 
 Item::Item(const DTO::BaseItemDto &data, ApiClient *apiClient, QObject *parent)
-    : DTO::BaseItemDto(data),
-      QObject(parent),
+    : QObject(parent),
+      DTO::BaseItemDto(data),
       m_apiClient(nullptr) {
     setApiClient(apiClient);
 }

--- a/core/src/model/playbackmanager.cpp
+++ b/core/src/model/playbackmanager.cpp
@@ -155,11 +155,13 @@ int PlaybackManager::queueIndex() const {
 
 void PlaybackManager::swap(PlaybackManager &other) {
     other.queue()->clearList();
-    other.queue()->appendToList(this->queue()->queueAndList());
-    other.playItemInList(this->queue()->queueAndList(), this->queue()->currentItemIndexInList() >= 0
-                                                            ? this->queue()->currentItemIndexInList()
-                                                            : 0);
-    other.seek(position());
+    if (other.queue()->listSize() > 0) {
+        other.queue()->appendToList(this->queue()->queueAndList());
+        other.playItemInList(this->queue()->queueAndList(), this->queue()->currentItemIndexInList() >= 0
+                                                                ? this->queue()->currentItemIndexInList()
+                                                                : 0);
+        other.seek(position());
+    }
 }
 
 void PlaybackManager::playItemId(const QString &id) {}

--- a/core/src/model/playbackmanager.cpp
+++ b/core/src/model/playbackmanager.cpp
@@ -203,6 +203,13 @@ void PlaybackManager::setItem(QSharedPointer<Item> item) {
     emit itemChanged();
 }
 
+void PlaybackManager::setQueueIndex(int index)
+{
+    Q_D(PlaybackManager);
+    d->m_queueIndex = index;
+    emit queueIndexChanged(index);
+}
+
 /*****************************************************************************
  * LocalPlaybackManagerPrivate                                               *
  *****************************************************************************/
@@ -611,9 +618,8 @@ void LocalPlaybackManager::playItemInList(const QList<QSharedPointer<Model::Item
     d->m_queue->clearList();
     d->m_queue->appendToList(items);
     d->m_queue->play(index);
-    d->m_queueIndex = index;
 
-    emit queueIndexChanged(d->m_queueIndex);
+    setQueueIndex(index);
 
     d->setItem(items.at(index));
     emit hasNextChanged(d->m_queue->hasNext());
@@ -624,8 +630,7 @@ void LocalPlaybackManager::playItemInList(const QList<QSharedPointer<Model::Item
 void LocalPlaybackManager::goTo(int index) {
     Q_D(LocalPlaybackManager);
     d->m_queue->play(index);
-    d->m_queueIndex = index;
-    emit queueIndexChanged(index);
+    setQueueIndex(index);
 
     d->setItem(d->m_queue->currentItem());
     emit hasNextChanged(d->m_queue->hasNext());

--- a/core/src/model/playbackmanager.cpp
+++ b/core/src/model/playbackmanager.cpp
@@ -59,7 +59,7 @@ public:
 
     PlayerState m_state;
 
-    Model::Playlist *m_queue = nullptr;
+    Model::Playlist *m_queue;
     int m_queueIndex = 0;
 
     bool m_resumePlayback = false;
@@ -153,6 +153,15 @@ int PlaybackManager::queueIndex() const {
     return d->m_queueIndex;
 }
 
+void PlaybackManager::swap(PlaybackManager &other) {
+    other.queue()->clearList();
+    other.queue()->appendToList(this->queue()->queueAndList());
+    other.playItemInList(this->queue()->queueAndList(), this->queue()->currentItemIndexInList() >= 0
+                                                            ? this->queue()->currentItemIndexInList()
+                                                            : 0);
+    other.seek(position());
+}
+
 void PlaybackManager::playItemId(const QString &id) {}
 
 bool PlaybackManager::resumePlayback() const {
@@ -186,6 +195,12 @@ void PlaybackManager::setSubtitleIndex(int newSubtitleIndex) {
     Q_D(PlaybackManager);
     d->m_subtitleIndex = newSubtitleIndex;
     emit subtitleIndexChanged(newSubtitleIndex);
+}
+
+void PlaybackManager::setItem(QSharedPointer<Item> item) {
+    Q_D(PlaybackManager);
+    d->m_item = item;
+    emit itemChanged();
 }
 
 /*****************************************************************************
@@ -489,10 +504,6 @@ LocalPlaybackManager::LocalPlaybackManager(QObject *parent)
     connect(d->m_mediaPlayer, &Player::errorStringChanged, this, [d]() {
         d->onPlayerError();
     });
-}
-
-void LocalPlaybackManager::swap(PlaybackManager &other) {
-    Q_UNIMPLEMENTED();
 }
 
 Player* LocalPlaybackManager::player() const {

--- a/core/src/model/player.cpp
+++ b/core/src/model/player.cpp
@@ -89,7 +89,7 @@ QtMultimediaPlayerPrivate::QtMultimediaPlayerPrivate(QtMultimediaPlayer *q)
     q->connect(m_mediaPlayer, &QMediaPlayer::seekableChanged, q, &QtMultimediaPlayer::seekableChanged);
     q->connect(m_mediaPlayer, &QMediaPlayer::audioAvailableChanged, q, &QtMultimediaPlayer::hasAudioChanged);
     q->connect(m_mediaPlayer, &QMediaPlayer::videoAvailableChanged, q, &QtMultimediaPlayer::hasVideoChanged);
-    q->connect(m_mediaPlayer, SIGNAL(error(QMediaPlayer::Error)), q, SLOT(errorStringChanged));
+    //q->connect(m_mediaPlayer, SIGNAL(error(QMediaPlayer::Error)), q, SLOT(errorStringChanged(QString)));
     if (m_mediaStreamsControl != nullptr) {
         q->connect(m_mediaStreamsControl, &QMediaStreamsControl::streamsChanged, q, [this](){
             qCDebug(player) << m_mediaStreamsControl->streamCount() << " streams in the medi source";

--- a/core/src/model/playlist.cpp
+++ b/core/src/model/playlist.cpp
@@ -180,17 +180,28 @@ void Playlist::reshuffle() {
 }
 
 void Playlist::play(int index) {
+    // We need to defend against indices that are outside of the playlist.
+    // The RemoteJellyfinPlaybackController will usually first update the now playing index
+    // before this playlist is updated. For example, if new playlist is bigger than
+    // the current and an item index out of range of the current playlist is requested.
+
     m_shuffler->setIndex(index);
     if (!m_nextItemFromQueue) {
         int nextItemIdx = m_shuffler->nextItem();
         if (nextItemIdx >= 0) {
-            m_nextItem = m_list[m_shuffler->nextItem()];
+            m_nextItem = m_list[nextItemIdx];
         } else {
             m_nextItem.clear();
         }
     }
-    m_currentItem = m_list[m_shuffler->currentItem()];
-    emit currentItemChanged();
+
+    if (m_shuffler->currentItem() >= 0) {
+        m_currentItem = m_list[m_shuffler->currentItem()];
+        emit currentItemChanged();
+    } else {
+        m_currentItem.clear();
+        emit currentItemChanged();
+    }
 }
 
 bool Playlist::playingFromQueue() const {

--- a/core/src/model/playlist.cpp
+++ b/core/src/model/playlist.cpp
@@ -104,6 +104,14 @@ void Playlist::next() {
     emit currentItemChanged();
 }
 
+QList<QSharedPointer<Item>> Playlist::queueAndList() const {
+    QList<QSharedPointer<Item>> result;
+    result.reserve(totalSize());
+    result.append(m_queue.toList());
+    result.append(m_list.toList());
+    return result;
+}
+
 QSharedPointer<const Item> Playlist::listAt(int index) const {
     if (m_shuffler->canShuffleInAdvance()) {
         return m_list.at(m_shuffler->itemAt(index));

--- a/core/src/model/remotejellyfinplayback.cpp
+++ b/core/src/model/remotejellyfinplayback.cpp
@@ -1,0 +1,132 @@
+/*
+ * Sailfin: a Jellyfin client written using Qt
+ * Copyright (C) 2023 Chris Josten and the Sailfin Contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <JellyfinQt/model/remotejellyfinplayback.h>
+
+#include <JellyfinQt/apiclient.h>
+#include <JellyfinQt/loader/http/session.h>
+#include <JellyfinQt/loader/requesttypes.h>
+
+namespace Jellyfin {
+namespace Model {
+
+RemoteJellyfinPlayback::RemoteJellyfinPlayback(ApiClient &apiClient, QObject *parent)
+    : PlaybackManager(parent), m_apiClient(apiClient) {
+
+}
+
+void RemoteJellyfinPlayback::swap(PlaybackManager &other) {
+
+}
+
+PlayerState RemoteJellyfinPlayback::playbackState() const {
+
+}
+
+MediaStatus RemoteJellyfinPlayback::mediaStatus() const {
+
+}
+
+bool RemoteJellyfinPlayback::hasNext() const {
+
+}
+
+bool RemoteJellyfinPlayback::hasPrevious() const {
+
+}
+
+PlaybackManagerError RemoteJellyfinPlayback::error() const {
+
+}
+
+const QString &RemoteJellyfinPlayback::errorString() const {
+
+}
+
+qint64 RemoteJellyfinPlayback::position() const {
+
+}
+
+qint64 RemoteJellyfinPlayback::duration() const {
+
+}
+
+bool RemoteJellyfinPlayback::seekable() const {
+
+}
+
+bool RemoteJellyfinPlayback::hasAudio() const {
+
+}
+
+bool RemoteJellyfinPlayback::hasVideo() const {
+
+}
+
+void RemoteJellyfinPlayback::playItem(QSharedPointer<Item> item) {
+
+}
+
+void RemoteJellyfinPlayback::playItemInList(const QList<QSharedPointer<Item> > &items, int index) {
+
+}
+
+void RemoteJellyfinPlayback::pause() {
+}
+
+void RemoteJellyfinPlayback::play() {
+
+}
+
+void RemoteJellyfinPlayback::playItemId(const QString &id) {
+
+}
+
+void RemoteJellyfinPlayback::previous() {
+
+}
+
+void RemoteJellyfinPlayback::next() {
+
+}
+
+void RemoteJellyfinPlayback::goTo(int index) {
+
+}
+
+void RemoteJellyfinPlayback::stop() {
+
+}
+
+void RemoteJellyfinPlayback::seek(qint64 pos) {
+
+}
+
+void RemoteJellyfinPlayback::sendGeneralCommand(DTO::GeneralCommandType command, QJsonObject arguments) {
+    Loader::SendFullGeneralCommandParams params;
+    QSharedPointer<DTO::GeneralCommand> fullCommand = QSharedPointer<DTO::GeneralCommand>::create(command, m_apiClient.userId());
+    fullCommand->setArguments(arguments);
+    // FIXME: send command
+}
+
+
+
+} // NS Model
+} // NS Jellyfin
+

--- a/core/src/model/remotejellyfinplayback.cpp
+++ b/core/src/model/remotejellyfinplayback.cpp
@@ -20,90 +20,127 @@
 #include <JellyfinQt/model/remotejellyfinplayback.h>
 
 #include <JellyfinQt/apiclient.h>
+#include <JellyfinQt/dto/sessioninfo.h>
 #include <JellyfinQt/loader/http/session.h>
 #include <JellyfinQt/loader/requesttypes.h>
+#include <JellyfinQt/model/item.h>
+#include <JellyfinQt/model/playlist.h>
+#include <JellyfinQt/eventbus.h>
+#include <JellyfinQt/websocket.h>
+
+#include <QDebug>
 
 namespace Jellyfin {
 namespace Model {
 
-RemoteJellyfinPlayback::RemoteJellyfinPlayback(ApiClient &apiClient, QObject *parent)
-    : PlaybackManager(parent), m_apiClient(apiClient) {
+RemoteJellyfinPlayback::RemoteJellyfinPlayback(ApiClient &apiClient, QString sessionId, QObject *parent)
+    : PlaybackManager(parent), m_apiClient(apiClient), m_sessionId(sessionId), m_positionTimer(new QTimer(this)) {
+    setApiClient(&m_apiClient);
+    m_apiClient.websocket()->subscribeToSessionInfo();
+    connect(m_apiClient.eventbus(), &EventBus::sessionInfoUpdated, this, &RemoteJellyfinPlayback::onSessionInfoUpdated);
 
+    // Arm the timer
+    m_positionTimer->setInterval(1000);
+    connect(m_positionTimer, &QTimer::timeout, this, &RemoteJellyfinPlayback::onPositionTimerFired);
 }
 
-void RemoteJellyfinPlayback::swap(PlaybackManager &other) {
-
+RemoteJellyfinPlayback::~RemoteJellyfinPlayback() {
+    m_apiClient.websocket()->unsubscribeToSessionInfo();
 }
 
 PlayerState RemoteJellyfinPlayback::playbackState() const {
-
+    return m_lastSessionInfo.has_value()
+            ? m_lastSessionInfo.value().playState()->isPaused()
+                    ? PlayerState::Paused
+                    : PlayerState::Playing
+            : PlayerState::Stopped;
 }
 
 MediaStatus RemoteJellyfinPlayback::mediaStatus() const {
-
+    return MediaStatus::Loaded;
 }
 
 bool RemoteJellyfinPlayback::hasNext() const {
-
+    return true;
 }
 
 bool RemoteJellyfinPlayback::hasPrevious() const {
-
+    return true;
 }
 
 PlaybackManagerError RemoteJellyfinPlayback::error() const {
-
+    return PlaybackManagerError::NoError;
 }
 
 const QString &RemoteJellyfinPlayback::errorString() const {
-
+    return m_sessionId;
 }
 
 qint64 RemoteJellyfinPlayback::position() const {
-
+    return m_position;
 }
 
 qint64 RemoteJellyfinPlayback::duration() const {
-
+    if (!m_lastSessionInfo.has_value()
+            || m_lastSessionInfo.value().nowPlayingItem().isNull()) {
+        return 0;
+    }
+    return m_lastSessionInfo.value().nowPlayingItem()->runTimeTicks().value_or(0) / 10000;
 }
 
 bool RemoteJellyfinPlayback::seekable() const {
-
+    if (!m_lastSessionInfo.has_value()
+            || m_lastSessionInfo.value().playState().isNull()) {
+        return false;
+    }
+    return m_lastSessionInfo.value().playState()->canSeek();
 }
 
 bool RemoteJellyfinPlayback::hasAudio() const {
-
+    return false;
 }
 
 bool RemoteJellyfinPlayback::hasVideo() const {
-
+    return false;
 }
 
 void RemoteJellyfinPlayback::playItem(QSharedPointer<Item> item) {
-
+    return playItemInList({item}, 0);
 }
 
 void RemoteJellyfinPlayback::playItemInList(const QList<QSharedPointer<Item> > &items, int index) {
+    // Map items to their ID
+    QStringList itemIds;
+    itemIds.reserve(items.size());
+    for(auto it = items.begin(); it < items.end(); it++) {
+        itemIds.append((*it)->jellyfinId());
+    }
 
+    if (this->resumePlayback()) {
+        this->playItemInList(itemIds, index, items.at(index)->userData()->playbackPositionTicks());
+    } else {
+        this->playItemInList(itemIds, index);
+    }
 }
 
 void RemoteJellyfinPlayback::pause() {
+    sendPlaystateCommand(DTO::PlaystateCommand::Pause);
 }
 
 void RemoteJellyfinPlayback::play() {
-
+    sendPlaystateCommand(DTO::PlaystateCommand::Unpause);
 }
 
 void RemoteJellyfinPlayback::playItemId(const QString &id) {
-
+    playItemInList({id}, 0);
 }
 
 void RemoteJellyfinPlayback::previous() {
-
+    sendPlaystateCommand(DTO::PlaystateCommand::PreviousTrack);
 }
 
 void RemoteJellyfinPlayback::next() {
-
+    sendPlaystateCommand(DTO::PlaystateCommand::NextTrack);
 }
 
 void RemoteJellyfinPlayback::goTo(int index) {
@@ -111,21 +148,107 @@ void RemoteJellyfinPlayback::goTo(int index) {
 }
 
 void RemoteJellyfinPlayback::stop() {
-
+    sendPlaystateCommand(DTO::PlaystateCommand::Stop);
 }
 
 void RemoteJellyfinPlayback::seek(qint64 pos) {
+    sendPlaystateCommand(DTO::PlaystateCommand::Seek, pos * PlaybackManager::MS_TICK_FACTOR);
+}
 
+void RemoteJellyfinPlayback::onPositionTimerFired() {
+    m_position += m_positionTimer->interval();
+    emit positionChanged(position());
+}
+
+void RemoteJellyfinPlayback::onSessionInfoUpdated(const QString &sessionId, const SessionInfo &sessionInfo) {
+    if (sessionId != m_sessionId) return;
+    qDebug() << "Session info updated for " << sessionId;
+    m_lastSessionInfo = sessionInfo;
+
+    if (m_lastSessionInfo->nowPlayingItem().isNull()) {
+        setItem(QSharedPointer<Model::Item>::create());
+    } else {
+        Jellyfin::BaseItemDto itemData = *m_lastSessionInfo->nowPlayingItem().data();
+        setItem(QSharedPointer<Model::Item>::create(itemData, &m_apiClient));
+    }
+
+    // Update current position and run timer if needed
+    if (m_lastSessionInfo.has_value()
+            && !m_lastSessionInfo.value().playState().isNull()) {
+        m_position = m_lastSessionInfo.value().playState()->positionTicks().value_or(0) / PlaybackManager::MS_TICK_FACTOR;
+        if (!m_positionTimer->isActive()  && !m_lastSessionInfo.value().playState()->isPaused()) {
+            m_positionTimer->start();
+        } else if (m_positionTimer->isActive()  && m_lastSessionInfo.value().playState()->isPaused()) {
+            m_positionTimer->stop();
+        }
+    } else if (m_positionTimer->isActive()){
+        m_positionTimer->stop();
+        m_position = 0;
+    }
+
+    emit playbackStateChanged(playbackState());
+    emit durationChanged(duration());
+    emit positionChanged(position());
+}
+
+void RemoteJellyfinPlayback::sendPlaystateCommand(DTO::PlaystateCommand command, qint64 seekTicks) {
+    using Params = Loader::SendPlaystateCommandParams;
+    using CommandLoader = Loader::HTTP::SendPlaystateCommandLoader;
+
+    Params params;
+    params.setCommand(command);
+    params.setSessionId(m_sessionId);
+    if (seekTicks >= 0) {
+        params.setSeekPositionTicks(seekTicks);
+    }
+
+    auto loader = new CommandLoader(&m_apiClient);
+    loader->setParameters(params);
+    sendCommand(loader);
 }
 
 void RemoteJellyfinPlayback::sendGeneralCommand(DTO::GeneralCommandType command, QJsonObject arguments) {
-    Loader::SendFullGeneralCommandParams params;
+    using Params = Loader::SendFullGeneralCommandParams;
+    using CommandLoader = Loader::HTTP::SendFullGeneralCommandLoader;
+
+    Params params;
     QSharedPointer<DTO::GeneralCommand> fullCommand = QSharedPointer<DTO::GeneralCommand>::create(command, m_apiClient.userId());
     fullCommand->setArguments(arguments);
-    // FIXME: send command
+    params.setBody(fullCommand);
+    params.setSessionId(m_sessionId);
+
+    auto loader = new CommandLoader(&m_apiClient);
+    loader->setParameters(params);
+    sendCommand(loader);
 }
 
+void RemoteJellyfinPlayback::sendCommand(Support::LoaderBase *loader) {
+    connect(loader, &Support::LoaderBase::ready, this, [loader](){
+        loader->deleteLater();
+    });
+    connect(loader, &Support::LoaderBase::error, this, [loader](QString message){
+        loader->deleteLater();
+    });
+    loader->load();
+}
 
+void RemoteJellyfinPlayback::playItemInList(const QStringList &items, int index, qint64 resumeTicks) {
+    using Params = Loader::PlayParams;
+    using CommandLoader = Loader::HTTP::PlayLoader;
+
+    Params params;
+    params.setSessionId(m_sessionId);
+    if (resumeTicks >= 0) {
+        params.setStartPositionTicks(resumeTicks);
+    }
+    params.setPlayCommand(DTO::PlayCommand::PlayNow);
+    params.setItemIds(items);
+    //params.setStartIndex(index);
+
+    CommandLoader *loader = new CommandLoader(&m_apiClient);
+    loader->setParameters(params);
+    sendCommand(loader);
+}
 
 } // NS Model
 } // NS Jellyfin

--- a/core/src/model/remotejellyfinplayback.cpp
+++ b/core/src/model/remotejellyfinplayback.cpp
@@ -119,7 +119,12 @@ void RemoteJellyfinPlayback::playItemInList(const QList<QSharedPointer<Item> > &
     }
 
     if (this->resumePlayback()) {
-        this->playItemInList(itemIds, index, items.at(index)->userData()->playbackPositionTicks());
+        QSharedPointer<DTO::UserData> userData = items.at(index)->userData();
+        if (userData) {
+            this->playItemInList(itemIds, index, items.at(index)->userData()->playbackPositionTicks());
+        } else {
+            this->playItemInList(itemIds, index, 0);
+        }
     } else {
         this->playItemInList(itemIds, index);
     }
@@ -271,6 +276,7 @@ void RemoteJellyfinPlayback::playItemInList(const QStringList &items, int index,
     }
     params.setPlayCommand(DTO::PlayCommand::PlayNow);
     params.setItemIds(items);
+    params.setMediaSourceId(items.at(index));
     params.setStartIndex(index);
     params.setAudioStreamIndex(this->audioIndex());
     if (this->subtitleIndex() >= 0) {

--- a/core/src/model/remotejellyfinplayback.cpp
+++ b/core/src/model/remotejellyfinplayback.cpp
@@ -243,7 +243,11 @@ void RemoteJellyfinPlayback::playItemInList(const QStringList &items, int index,
     }
     params.setPlayCommand(DTO::PlayCommand::PlayNow);
     params.setItemIds(items);
-    //params.setStartIndex(index);
+    params.setStartIndex(index);
+    params.setAudioStreamIndex(this->audioIndex());
+    if (this->subtitleIndex() >= 0) {
+        params.setSubtitleStreamIndex(this->subtitleIndex());
+    }
 
     CommandLoader *loader = new CommandLoader(&m_apiClient);
     loader->setParameters(params);

--- a/core/src/model/shuffle.cpp
+++ b/core/src/model/shuffle.cpp
@@ -80,7 +80,7 @@ int NoShuffle::nextIndex() const {
         return (m_index + 1) % m_playlist->listSize();
     } else {
         if (m_index + 1 >= m_playlist->listSize()) {
-            return 0;
+            return -1;
         } else {
             return m_index + 1;
         }
@@ -88,7 +88,11 @@ int NoShuffle::nextIndex() const {
 }
 
 void NoShuffle::setIndex(int i) {
-    m_index = i;
+    if (i >= 0 && i < m_playlist->listSize()) {
+        m_index = i;
+    } else {
+        m_index = -1;
+    }
 }
 
 // ListShuffleBase

--- a/core/src/platform/freedesktop/mediaplayer2player.cpp
+++ b/core/src/platform/freedesktop/mediaplayer2player.cpp
@@ -46,37 +46,37 @@ PlayerAdaptor::~PlayerAdaptor() {
 bool PlayerAdaptor::canControl() const
 {
     // get the value of property CanControl
-    return true;
+    return m_mediaControl->playbackManager() != nullptr;
 }
 
 bool PlayerAdaptor::canGoNext() const
 {
     // get the value of property CanGoNext
-    return canPlay() && m_mediaControl->playbackManager()->hasNext();
+    return canControl() && canPlay() && m_mediaControl->playbackManager()->hasNext();
 }
 
 bool PlayerAdaptor::canGoPrevious() const
 {
     // get the value of property CanGoPrevious
-    return canPlay() && m_mediaControl->playbackManager()->hasPrevious();
+    return canControl() && canPlay() && m_mediaControl->playbackManager()->hasPrevious();
 }
 
 bool PlayerAdaptor::canPause() const
 {
     // get the value of property CanPause
-    return canPlay();
+    return canControl() && canPlay();
 }
 
 bool PlayerAdaptor::canPlay() const
 {
     // get the value of property CanPlay
-    return m_mediaControl->playbackManager()->queue()->rowCount(QModelIndex()) > 0;
+    return canControl() && m_mediaControl->playbackManager()->queue()->rowCount(QModelIndex()) > 0;
 }
 
 bool PlayerAdaptor::canSeek() const
 {
     // get the value of property CanSeek
-    return m_mediaControl->playbackManager()->seekable();
+    return canControl() && m_mediaControl->playbackManager()->seekable();
 }
 
 QString PlayerAdaptor::loopStatus() const
@@ -134,7 +134,10 @@ QVariantMap PlayerAdaptor::metadata() const
         }
         map[QStringLiteral("xesam:contentCreated")] = item->dateCreated();
         map[QStringLiteral("xesam:genre")] = item->genres();
-        map[QStringLiteral("xesam:lastUsed")] = item->userData()->lastPlayedDate();
+
+        if (!item->userData().isNull()) {
+            map[QStringLiteral("xesam:lastUsed")] = item->userData()->lastPlayedDate();
+        }
 
         QJsonObject providers = item->providerIds();
         if (providers.contains(QStringLiteral("MusicBrainzTrack"))) {

--- a/core/src/viewmodel/playbackmanager.cpp
+++ b/core/src/viewmodel/playbackmanager.cpp
@@ -182,8 +182,12 @@ void PlaybackManager::setControllingSession(QSharedPointer<Model::ControllableSe
         // Stop playing locally when switching to another session
         if (thisIsLocal) {
             d->m_impl->stop();
+            if (other != nullptr) {
+                d->m_impl->swap(*other);
+            }
         }
     }
+
     d->m_displayQueue->setPlaylistModel(other->queue());
     d->m_impl.reset(other);
     d->m_session.swap(session);

--- a/core/src/viewmodel/playbackmanager.cpp
+++ b/core/src/viewmodel/playbackmanager.cpp
@@ -195,13 +195,21 @@ void PlaybackManager::setControllingSession(QSharedPointer<Model::ControllableSe
 
     if (other != nullptr) {
         connect(d->m_impl.data(), &Model::PlaybackManager::positionChanged, this, &PlaybackManager::positionChanged);
+        emit positionChanged(d->m_impl->position());
         connect(d->m_impl.data(), &Model::PlaybackManager::durationChanged, this, &PlaybackManager::durationChanged);
+        emit durationChanged(d->m_impl->duration());
         connect(d->m_impl.data(), &Model::PlaybackManager::hasNextChanged, this, &PlaybackManager::hasNextChanged);
+        emit hasNextChanged(d->m_impl->hasNext());
         connect(d->m_impl.data(), &Model::PlaybackManager::hasPreviousChanged, this, &PlaybackManager::hasPreviousChanged);
+        emit hasPreviousChanged(d->m_impl->hasPrevious());
         connect(d->m_impl.data(), &Model::PlaybackManager::seekableChanged, this, &PlaybackManager::seekableChanged);
+        emit seekableChanged(d->m_impl->seekable());
         connect(d->m_impl.data(), &Model::PlaybackManager::queueIndexChanged, this, &PlaybackManager::queueIndexChanged);
+        emit queueIndexChanged(d->m_impl->queueIndex());
         connect(d->m_impl.data(), &Model::PlaybackManager::itemChanged, this, &PlaybackManager::mediaPlayerItemChanged);
+        emit itemChanged();
         connect(d->m_impl.data(), &Model::PlaybackManager::playbackStateChanged, this, &PlaybackManager::playbackStateChanged);
+        emit playbackStateChanged(d->m_impl->playbackState());
 
         if (auto localImp = qobject_cast<Model::LocalPlaybackManager*>(d->m_impl.data())) {
             connect(localImp, &Model::LocalPlaybackManager::streamUrlChanged, this, [this](const QUrl& newUrl){
@@ -209,7 +217,9 @@ void PlaybackManager::setControllingSession(QSharedPointer<Model::ControllableSe
             });
             connect(localImp, &Model::LocalPlaybackManager::playMethodChanged, this, &PlaybackManager::playMethodChanged);
         }
+        emit streamUrlChanged(streamUrl());
         connect(d->m_impl.data(), &Model::PlaybackManager::mediaStatusChanged, this, &PlaybackManager::mediaStatusChanged);
+        emit mediaStatusChanged(d->m_impl->mediaStatus());
     }
 }
 

--- a/core/src/viewmodel/playbackmanager.cpp
+++ b/core/src/viewmodel/playbackmanager.cpp
@@ -23,10 +23,13 @@
 #include <JellyfinQt/dto/playstatecommand.h>
 #include <JellyfinQt/dto/playstaterequest.h>
 
-// #include "JellyfinQt/DTO/dto.h"
 #include <JellyfinQt/dto/useritemdatadto.h>
+#include <JellyfinQt/model/controllablesession.h>
 #include <JellyfinQt/model/playbackmanager.h>
 #include <JellyfinQt/viewmodel/settings.h>
+
+#include <QSharedPointer>
+
 #include <utility>
 
 namespace Jellyfin {
@@ -47,7 +50,8 @@ public:
     PlaybackManager *q_ptr = nullptr;
 
     ApiClient *m_apiClient = nullptr;
-    Model::PlaybackManager *m_impl = nullptr;
+    QSharedPointer<Model::ControllableSession> m_session;
+    QScopedPointer<Model::PlaybackManager> m_impl;
 
     /// The currently played item that will be shown in the GUI
     ViewModel::Item *m_displayItem = nullptr;
@@ -59,6 +63,7 @@ public:
 
 PlaybackManagerPrivate::PlaybackManagerPrivate(PlaybackManager *q)
     : q_ptr(q),
+      m_session(nullptr),
       m_impl(new Model::LocalPlaybackManager(q)),
       m_displayItem(new ViewModel::Item(q)),
       m_displayQueue(new ViewModel::Playlist(m_impl->queue())) {
@@ -73,21 +78,22 @@ PlaybackManager::PlaybackManager(QObject *parent)
 
     Q_D(PlaybackManager);
     // Set up connections.
-    connect(d->m_impl, &Model::PlaybackManager::positionChanged, this, &PlaybackManager::positionChanged);
-    connect(d->m_impl, &Model::PlaybackManager::durationChanged, this, &PlaybackManager::durationChanged);
-    connect(d->m_impl, &Model::PlaybackManager::hasNextChanged, this, &PlaybackManager::hasNextChanged);
-    connect(d->m_impl, &Model::PlaybackManager::hasPreviousChanged, this, &PlaybackManager::hasPreviousChanged);
-    connect(d->m_impl, &Model::PlaybackManager::seekableChanged, this, &PlaybackManager::seekableChanged);
-    connect(d->m_impl, &Model::PlaybackManager::queueIndexChanged, this, &PlaybackManager::queueIndexChanged);
-    connect(d->m_impl, &Model::PlaybackManager::itemChanged, this, &PlaybackManager::mediaPlayerItemChanged);
-    connect(d->m_impl, &Model::PlaybackManager::playbackStateChanged, this, &PlaybackManager::playbackStateChanged);
-    if (auto localImp = qobject_cast<Model::LocalPlaybackManager*>(d->m_impl)) {
+    connect(d->m_impl.data(), &Model::PlaybackManager::positionChanged, this, &PlaybackManager::positionChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::durationChanged, this, &PlaybackManager::durationChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::hasNextChanged, this, &PlaybackManager::hasNextChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::hasPreviousChanged, this, &PlaybackManager::hasPreviousChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::seekableChanged, this, &PlaybackManager::seekableChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::queueIndexChanged, this, &PlaybackManager::queueIndexChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::itemChanged, this, &PlaybackManager::mediaPlayerItemChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::playbackStateChanged, this, &PlaybackManager::playbackStateChanged);
+
+    if (auto localImp = qobject_cast<Model::LocalPlaybackManager*>(d->m_impl.data())) {
         connect(localImp, &Model::LocalPlaybackManager::streamUrlChanged, this, [this](const QUrl& newUrl){
-            this->streamUrlChanged(newUrl.toString());
+            emit this->streamUrlChanged(newUrl.toString());
         });
         connect(localImp, &Model::LocalPlaybackManager::playMethodChanged, this, &PlaybackManager::playMethodChanged);
     }
-    connect(d->m_impl, &Model::PlaybackManager::mediaStatusChanged, this, &PlaybackManager::mediaStatusChanged);
+    connect(d->m_impl.data(), &Model::PlaybackManager::mediaStatusChanged, this, &PlaybackManager::mediaStatusChanged);
 }
 
 PlaybackManager::~PlaybackManager() {
@@ -107,6 +113,10 @@ void PlaybackManager::setApiClient(ApiClient *apiClient) {
     d->m_impl->setApiClient(apiClient);
 
     if (d->m_apiClient != nullptr) {
+        // Set the session to a new LocalSession in case it hasn't been set yet.
+        if (d->m_session.isNull()) {
+            setControllingSession(QSharedPointer<Model::LocalSession>::create(*apiClient, this));
+        }
         connect(d->m_apiClient->eventbus(), &EventBus::playstateCommandReceived, this, &PlaybackManager::handlePlaystateRequest);
     }
 }
@@ -155,9 +165,42 @@ ApiClient * PlaybackManager::apiClient() const {
     return d->m_apiClient;
 }
 
+QSharedPointer<Model::ControllableSession> PlaybackManager::controllingSession() const {
+    const Q_D(PlaybackManager);
+    return d->m_session;
+}
+
+void PlaybackManager::setControllingSession(QSharedPointer<Model::ControllableSession> session) {
+    Q_D(PlaybackManager);
+
+    qCDebug(playbackManager()) << "Now controlling session " << session->name();
+    session->setParent(this);
+    d->m_session.swap(session);
+    // TODO: swap out playback manager
+    emit controllingSessionChanged();
+    emit controllingSessionIdChanged();
+    emit controllingSessionNameChanged();
+    emit controllingSessionLocalChanged();
+}
+
+QString PlaybackManager::controllingSessionId() const {
+    const Q_D(PlaybackManager);
+    return d->m_session->id();
+}
+
+QString PlaybackManager::controllingSessionName() const {
+    const Q_D(PlaybackManager);
+    return d->m_session->name();
+}
+
+bool PlaybackManager::controllingSessionLocal() const {
+    const Q_D(PlaybackManager);
+    return qobject_cast<Model::LocalPlaybackManager *>(d->m_impl.data()) != nullptr;
+}
+
 QString PlaybackManager::streamUrl() const {
     const Q_D(PlaybackManager);
-    if (Model::LocalPlaybackManager *lpm = qobject_cast<Model::LocalPlaybackManager *>(d->m_impl)) {
+    if (Model::LocalPlaybackManager *lpm = qobject_cast<Model::LocalPlaybackManager *>(d->m_impl.data())) {
         return lpm->streamUrl().toString();
     } else {
         return QStringLiteral("<not playing back locally>");
@@ -166,7 +209,7 @@ QString PlaybackManager::streamUrl() const {
 
 PlayMethod PlaybackManager::playMethod() const {
     const Q_D(PlaybackManager);
-    if (Model::LocalPlaybackManager *lpm = qobject_cast<Model::LocalPlaybackManager *>(d->m_impl)) {
+    if (Model::LocalPlaybackManager *lpm = qobject_cast<Model::LocalPlaybackManager *>(d->m_impl.data())) {
         return lpm->playMethod();
     } else {
         return PlayMethod::EnumNotSet;
@@ -210,7 +253,7 @@ bool PlaybackManager::hasPrevious() const {
 
 QObject* PlaybackManager::mediaObject() const {
     const Q_D(PlaybackManager);
-    if (auto localPb = qobject_cast<Model::LocalPlaybackManager*>(d->m_impl)) {
+    if (auto localPb = qobject_cast<Model::LocalPlaybackManager*>(d->m_impl.data())) {
         return localPb->player()->videoOutputSource();
     } else {
         return nullptr;

--- a/core/src/viewmodel/playlist.cpp
+++ b/core/src/viewmodel/playlist.cpp
@@ -26,20 +26,8 @@ namespace ViewModel {
 
 Playlist::Playlist(Model::Playlist *data, QObject *parent)
     : QAbstractListModel(parent),
-      m_data(data) {
-
-    connect(data, &Model::Playlist::beforeListCleared, this, &Playlist::onBeforePlaylistCleared);
-    connect(data, &Model::Playlist::listCleared, this, &Playlist::onPlaylistCleared);
-    connect(data, &Model::Playlist::beforeItemsAddedToList, this, &Playlist::onBeforeItemsAddedToList);
-    connect(data, &Model::Playlist::beforeItemsAddedToQueue, this, &Playlist::onBeforeItemsAddedToQueue);
-    connect(data, &Model::Playlist::itemsAddedToList, this, &Playlist::onItemsAddedToList);
-    connect(data, &Model::Playlist::itemsAddedToQueue, this, &Playlist::onItemsAddedToQueue);
-    connect(data, &Model::Playlist::beforeItemsRemovedFromList, this, &Playlist::onBeforeItemsRemovedFromList);
-    connect(data, &Model::Playlist::beforeItemsRemovedFromQueue, this, &Playlist::onBeforeItemsRemovedFromQueue);
-    connect(data, &Model::Playlist::itemsRemovedFromList, this, &Playlist::onItemsRemovedFromList);
-    connect(data, &Model::Playlist::itemsRemovedFromQueue, this, &Playlist::onItemsRemovedFromQueue);
-    connect(data, &Model::Playlist::listReshuffled, this, &Playlist::onReshuffled);
-    connect(data, &Model::Playlist::currentItemChanged, this, &Playlist::onPlayingItemChanged);
+      m_data(nullptr) {
+    setPlaylistModel(data);
 }
 
 int Playlist::rowCount(const QModelIndex &parent) const {
@@ -55,6 +43,41 @@ QHash<int, QByteArray> Playlist::roleNames() const {
         {RoleNames::section, "section"},
         {RoleNames::playing, "playing"},
     };
+}
+
+void Playlist::setPlaylistModel(Model::Playlist *data) {
+    if (m_data != nullptr) {
+        disconnect(data, &Model::Playlist::beforeListCleared, this, &Playlist::onBeforePlaylistCleared);
+        disconnect(data, &Model::Playlist::listCleared, this, &Playlist::onPlaylistCleared);
+        disconnect(data, &Model::Playlist::beforeItemsAddedToList, this, &Playlist::onBeforeItemsAddedToList);
+        disconnect(data, &Model::Playlist::beforeItemsAddedToQueue, this, &Playlist::onBeforeItemsAddedToQueue);
+        disconnect(data, &Model::Playlist::itemsAddedToList, this, &Playlist::onItemsAddedToList);
+        disconnect(data, &Model::Playlist::itemsAddedToQueue, this, &Playlist::onItemsAddedToQueue);
+        disconnect(data, &Model::Playlist::beforeItemsRemovedFromList, this, &Playlist::onBeforeItemsRemovedFromList);
+        disconnect(data, &Model::Playlist::beforeItemsRemovedFromQueue, this, &Playlist::onBeforeItemsRemovedFromQueue);
+        disconnect(data, &Model::Playlist::itemsRemovedFromList, this, &Playlist::onItemsRemovedFromList);
+        disconnect(data, &Model::Playlist::itemsRemovedFromQueue, this, &Playlist::onItemsRemovedFromQueue);
+        disconnect(data, &Model::Playlist::listReshuffled, this, &Playlist::onReshuffled);
+        disconnect(data, &Model::Playlist::currentItemChanged, this, &Playlist::onPlayingItemChanged);
+    }
+    beginResetModel();
+    m_data = data;
+    endResetModel();
+
+    if (m_data != nullptr) {
+        connect(data, &Model::Playlist::beforeListCleared, this, &Playlist::onBeforePlaylistCleared);
+        connect(data, &Model::Playlist::listCleared, this, &Playlist::onPlaylistCleared);
+        connect(data, &Model::Playlist::beforeItemsAddedToList, this, &Playlist::onBeforeItemsAddedToList);
+        connect(data, &Model::Playlist::beforeItemsAddedToQueue, this, &Playlist::onBeforeItemsAddedToQueue);
+        connect(data, &Model::Playlist::itemsAddedToList, this, &Playlist::onItemsAddedToList);
+        connect(data, &Model::Playlist::itemsAddedToQueue, this, &Playlist::onItemsAddedToQueue);
+        connect(data, &Model::Playlist::beforeItemsRemovedFromList, this, &Playlist::onBeforeItemsRemovedFromList);
+        connect(data, &Model::Playlist::beforeItemsRemovedFromQueue, this, &Playlist::onBeforeItemsRemovedFromQueue);
+        connect(data, &Model::Playlist::itemsRemovedFromList, this, &Playlist::onItemsRemovedFromList);
+        connect(data, &Model::Playlist::itemsRemovedFromQueue, this, &Playlist::onItemsRemovedFromQueue);
+        connect(data, &Model::Playlist::listReshuffled, this, &Playlist::onReshuffled);
+        connect(data, &Model::Playlist::currentItemChanged, this, &Playlist::onPlayingItemChanged);
+    }
 };
 
 QVariant Playlist::data(const QModelIndex &index, int role) const {

--- a/core/src/viewmodel/remotedevice.cpp
+++ b/core/src/viewmodel/remotedevice.cpp
@@ -1,0 +1,152 @@
+/*
+ * Sailfin: a Jellyfin client written using Qt
+ * Copyright (C) 2022 Chris Josten and the Sailfin Contributors.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <JellyfinQt/viewmodel/remotedevice.h>
+
+#include <JellyfinQt/model/controllablesession.h>
+#include <JellyfinQt/viewmodel/playbackmanager.h>
+
+namespace Jellyfin {
+namespace ViewModel {
+
+RemoteDeviceList::RemoteDeviceList(QObject *parent)
+    : QAbstractListModel(parent) {}
+
+void RemoteDeviceList::classBegin() {}
+void RemoteDeviceList::componentComplete() {
+    m_componentComplete = true;
+    if (m_apiClient != nullptr) {
+        setApiClient(m_apiClient);
+    }
+}
+
+void RemoteDeviceList::setApiClient(ApiClient *apiClient) {
+    if (m_apiClient != nullptr) {
+        for (auto it = m_scanners.begin(); it != m_scanners.end(); it++) {
+            disconnect(*it, &Model::RemoteSessionScanner::sessionFound, this, &RemoteDeviceList::onSessionFound);
+            disconnect(*it, &Model::RemoteSessionScanner::sessionLost, this, &RemoteDeviceList::onSessionLost);
+            disconnect(*it, &Model::RemoteSessionScanner::resetSessions, this, &RemoteDeviceList::onSessionsReset);
+        }
+        for (auto it = m_sessions.begin(); it != m_sessions.end(); it++) {
+            it->first->stopScanning();
+            it->first->deleteLater();
+            it->second->deleteLater();
+        }
+        m_scanners.clear();
+        m_sessions.clear();
+    }
+    m_apiClient = apiClient;
+    emit apiClientChanged();
+    if (!m_componentComplete) return;
+
+    m_scanners.append(new Model::RemoteJellyfinSessionScanner(m_apiClient, this));
+    for (auto it = m_scanners.begin(); it != m_scanners.end(); it++) {
+        connect(*it, &Model::RemoteSessionScanner::sessionFound, this, &RemoteDeviceList::onSessionFound);
+        connect(*it, &Model::RemoteSessionScanner::sessionLost, this, &RemoteDeviceList::onSessionLost);
+        connect(*it, &Model::RemoteSessionScanner::resetSessions, this, &RemoteDeviceList::onSessionsReset);
+    }
+}
+
+int RemoteDeviceList::rowCount(const QModelIndex &parent) const {
+    return m_sessions.size();
+}
+
+QVariant RemoteDeviceList::data(const QModelIndex &index, int role) const {
+    int row = index.row();
+    if (!index.isValid() || row < 0 || row > rowCount()) return QVariant();
+    const QSharedPointer<Model::ControllableSession> session = m_sessions.at(row).second;
+    if (session.isNull()) return QVariant();
+
+    switch (role) {
+    case RoleNames::jellyfinId:
+        return session->id();
+    case RoleNames::name:
+        return session->name();
+    case RoleNames::deviceName:
+        return session->appName();
+    case RoleNames::deviceType:
+        return QVariant::fromValue<Model::DeviceType>(session->deviceType());
+    case RoleNames::userName:
+        return session->userName();
+    default:
+        return QVariant();
+    }
+}
+
+void RemoteDeviceList::activateSession(PlaybackManager *manager, int index) {
+    manager->setControllingSession(m_sessions.at(index).second);
+}
+
+void RemoteDeviceList::setScanning(bool scanning) {
+    if (scanning == m_scanning) return;
+    m_scanning = scanning;
+    emit scanningChanged();
+
+    if (scanning) {
+        for (auto it = m_scanners.begin(); it != m_scanners.end(); it++) {
+            (*it)->startScanning();
+        }
+    } else {
+        for (auto it = m_scanners.begin(); it != m_scanners.end(); it++) {
+            (*it)->stopScanning();
+        }
+    }
+}
+
+void RemoteDeviceList::onSessionFound(Model::ControllableSession *session) {
+    beginInsertRows(QModelIndex(), rowCount(), rowCount());
+    m_sessions.append(std::make_pair(qobject_cast<Model::RemoteSessionScanner *>(sender()), QSharedPointer<Model::ControllableSession>(session)));
+    endInsertRows();
+}
+
+void RemoteDeviceList::onSessionLost(QString sessionId) {
+    Model::RemoteSessionScanner *scanner = qobject_cast<Model::RemoteSessionScanner *>(sender());
+    for (int i = 0; i < m_sessions.size(); i++) {
+        auto row = m_sessions.at(i);
+        if (row.first == scanner && row.second->name() == sessionId) {
+            beginRemoveRows(QModelIndex(), i, i);
+            m_sessions.removeAt(i);
+            if (row.second->parent() == this) {
+                row.second->deleteLater();
+            }
+            endRemoveRows();
+            i--;
+        }
+    }
+}
+
+void RemoteDeviceList::onSessionsReset() {
+    Model::RemoteSessionScanner *scanner = qobject_cast<Model::RemoteSessionScanner *>(sender());
+    for (int i = 0; i < m_sessions.size(); i++) {
+        auto row = m_sessions.at(i);
+        if (row.first == scanner) {
+            beginRemoveRows(QModelIndex(), i, i);
+            m_sessions.removeAt(i);
+            if (row.second->parent() == this) {
+                row.second->deleteLater();
+            }
+            endRemoveRows();
+            i--;
+        }
+    }
+}
+
+
+} // NS Model
+} // NS Jellyfin

--- a/rpm/harbour-sailfin.changes
+++ b/rpm/harbour-sailfin.changes
@@ -14,6 +14,8 @@
 #
 * Future version Chris Josten <chris@netsoj.nl> 0.??.??-1
 - New features
+  - Allow remote controlling other Jellyfin clients. See the pulley item on the main screen named 
+    "Remote Control"
   - New layout for artist pages
   - New layout for the music library
   - New layout for playlist pages

--- a/sailfish/CMakeLists.txt
+++ b/sailfish/CMakeLists.txt
@@ -26,7 +26,7 @@ set(sailfin_QML_SOURCES
 	qml/components/videoplayer/VideoError.qml
 	qml/components/videoplayer/VideoHud.qml
 	qml/components/IconListItem.qml
-    qml/components/ItemChildrenShowcase.qml
+	qml/components/ItemChildrenShowcase.qml
 	qml/components/JItem.qml
 	qml/components/LibraryItemDelegate.qml
 	qml/components/MoreSection.qml
@@ -39,14 +39,15 @@ set(sailfin_QML_SOURCES
 	qml/components/UserGridDelegate.qml
 	qml/components/VideoPlayer.qml
 	qml/components/VideoTrackSelector.qml
-        qml/cover/CollectionPage.qml
+	qml/cover/CollectionPage.qml
 	qml/cover/PosterCover.qml
-        qml/cover/NowPlayingCover.qml
+	qml/cover/NowPlayingCover.qml
 	qml/pages/LegalPage.qml
 	qml/pages/MainPage.qml
 	qml/pages/AboutPage.qml
-        qml/harbour-sailfin.qml
-        qml/pages/ConnectingPage.qml
+	qml/harbour-sailfin.qml
+	qml/pages/ConnectingPage.qml
+	qml/pages/ControllableDevicesPage.qml
 	qml/pages/SettingsPage.qml
 	qml/pages/VideoPage.qml
 	qml/pages/itemdetails/BaseDetailPage.qml
@@ -54,8 +55,8 @@ set(sailfin_QML_SOURCES
 	qml/pages/itemdetails/EpisodePage.qml
 	qml/pages/itemdetails/FilmPage.qml
 	qml/pages/itemdetails/MusicAlbumPage.qml
-    qml/pages/itemdetails/MusicArtistPage.qml
-    qml/pages/itemdetails/MusicLibraryPage.qml
+	qml/pages/itemdetails/MusicArtistPage.qml
+	qml/pages/itemdetails/MusicLibraryPage.qml
 	qml/pages/itemdetails/PhotoPage.qml
 	qml/pages/itemdetails/SeasonPage.qml
 	qml/pages/itemdetails/SeriesPage.qml

--- a/sailfish/qml/Utils.js
+++ b/sailfish/qml/Utils.js
@@ -69,7 +69,11 @@ function randomBackdrop(baseUrl, item) {
 
 function itemBackdropUrl(baseUrl, item, idx, options) {
     var extraQuery = propsToQuery(options)
-    return baseUrl + "/Items/" + item.jellyfinId + "/Images/Backdrop/" + idx + "?tag=" + item.backdropImageTags[idx] + extraQuery;
+    if (item.backdropImageTags[idx]) {
+        return baseUrl + "/Items/" + item.jellyfinId + "/Images/Backdrop/" + idx + "?tag=" + item.backdropImageTags[idx] + extraQuery;
+    } else {
+        return baseUrl + "/Items/" + item.parentBackdropItemId + "/Images/Backdrop/" + idx + "?tag=" + item.parentBackdropImageTags[idx] + extraQuery;
+    }
 }
 
 

--- a/sailfish/qml/components/PlaybackBar.qml
+++ b/sailfish/qml/components/PlaybackBar.qml
@@ -48,6 +48,8 @@ PanelBackground {
     property bool showQueue: false
 
     property bool _pageWasShowingNavigationIndicator
+    readonly property bool _isItemSet: manager.item !== null && manager.item !== undefined && manager.item.jellyfinId.length > 0
+    readonly property bool controllingRemote: !manager.controllingSessionLocal
     readonly property bool mediaLoading: [J.MediaStatus.Loading, J.MediaStatus.Buffering].indexOf(manager.mediaStatus) >= 0
 
 
@@ -67,9 +69,12 @@ PanelBackground {
                 top: parent.top
             }
             width: height
-            Binding on blurhash {
-                when: manager.item !== null && "Primary" in manager.item.imageBlurHashes && "Primary" in manager.item.imageTags
-                value: manager.item.imageBlurHashes["Primary"][manager.item.imageTags["Primary"]]
+            blurhash: {
+                if (_isItemSet && "Primary" in manager.item.imageBlurHashes && "Primary" in manager.item.imageTags) {
+                    return manager.item.imageBlurHashes["Primary"][manager.item.imageTags["Primary"]]
+                } else {
+                    return ""
+                }
             }
             source: largeAlbumArt.source
             fillMode: Image.PreserveAspectCrop
@@ -125,7 +130,10 @@ PanelBackground {
 
             Label {
                 id: name
-                text: manager.item === null ? qsTr("No media selected") : manager.item.name
+                text: manager.item.jellyfinId
+                      ? manager.item.name
+                      //: Shown in a bright font when no media is playing in the bottom bar and now playing screen
+                      : qsTr("Nothing is playing")
                 width: Math.min(contentWidth, parent.width)
                 font.pixelSize: Theme.fontSizeMedium
                 maximumLineCount: 1
@@ -133,8 +141,23 @@ PanelBackground {
             }
             Label {
                 id: artists
+                leftPadding: controllingRemote ? remoteIcon.width + Theme.paddingSmall : 0
                 text: {
-                    if (manager.item === null) return qsTr("Play some media!")
+                    if (!_isItemSet) {
+                        if (controllingRemote) {
+                            //: Shown when no media is being played, but the app is controlling another Jellyfin client
+                            //: %1 is the name of said client
+                            return qsTr("Connected to %1").arg(manager.controllingSessionName)
+                        } else {
+                            return qsTr("Start playing some media!")
+                        }
+                    }
+                    var remoteText = "";
+
+                    if (controllingRemote) {
+                        remoteText = manager.controllingSessionName + " - "
+                    }
+
                     switch(manager.item.mediaType) {
                     case "Audio":
                         var links = [];
@@ -147,7 +170,7 @@ PanelBackground {
                                 .arg(Theme.secondaryColor)
                             )
                         }
-                        return links.join(", ")
+                        return remoteText + links.join(", ")
                     }
                     return qsTr("No audio")
                 }
@@ -162,6 +185,16 @@ PanelBackground {
                     appWindow.navigateToItem(link, "Audio", "MusicArtist", true)
                 }
                 textFormat: Text.StyledText
+                Icon {
+                    id: remoteIcon
+                    anchors {
+                        left: parent.left
+                        verticalCenter: parent.verticalCenter
+                    }
+                    height: parent
+                    source: "image://theme/icon-s-device-upload"
+                    visible: controllingRemote
+                }
             }
         }
 
@@ -395,7 +428,9 @@ PanelBackground {
         },
         State {
             name: "hidden"
-            when: ((manager.playbackState === J.PlayerState.Stopped && !mediaLoading) || "__hidePlaybackBar" in pageStack.currentPage) && !isFullPage
+            when: ((manager.playbackState === J.PlayerState.Stopped && !mediaLoading)
+                    || ("__hidePlaybackBar" in pageStack.currentPage && pageStack.currentPage.__hidePlaybackBar))
+                  && !isFullPage
             PropertyChanges {
                 target: playbackBarTranslate
                 // + small padding since the ProgressBar otherwise would stick out

--- a/sailfish/qml/components/PlaybackBar.qml
+++ b/sailfish/qml/components/PlaybackBar.qml
@@ -267,7 +267,16 @@ PanelBackground {
    states: [
        State {
            name: ""
-           when: manager.playbackState !== J.PlayerState.Stopped && !isFullPage && !("__hidePlaybackBar" in pageStack.currentPage)
+           // Show the bar whenever:
+           // 1. Either one of the following is true:
+           //    a. The playbackmanager is playing media
+           //    b. The playbackmanager is controlling a remote session
+           // AND
+           // 2. The playback bar isn't in the full page state
+           // AND
+           // 3. The topmost page on the pagestack hasn't requested to hide the page
+           when: (manager.playbackState !== J.PlayerState.Stopped || !manager.controllingSessionLocal)
+                 && !isFullPage && !("__hidePlaybackBar" in pageStack.currentPage)
        },
        State {
            name: "large"

--- a/sailfish/qml/components/VideoPlayer.qml
+++ b/sailfish/qml/components/VideoPlayer.qml
@@ -50,6 +50,16 @@ SilicaItem {
         color: Theme.overlayBackgroundColor
     }
 
+    RemoteImage {
+        id: backdrop
+        anchors.fill: parent
+        visible: !manager.controllingSessionLocal
+                  || [J.MediaStatus.NoMedia, J.MediaStatus.Loading].indexOf(manager.mediaStatus) >= 0
+        fillMode: Image.PreserveAspectFit
+        source: Utils.itemBackdropUrl(apiClient.baseUrl, item, 0, {"maxWidth": parent.width})
+        blurhash: item.imageBlurHashes["Backdrop"][item.backdropImageTags[0]]
+    }
+
     VideoOutput {
         id: videoOutput
         source: manager
@@ -64,7 +74,7 @@ SilicaItem {
         anchors.fill: parent
         manager: playerRoot.manager
         title: videoPlayer.title
-
+        alwaysVisible: !manager.controllingSessionLocal
     }
 
     VideoError {

--- a/sailfish/qml/components/videoplayer/VideoHud.qml
+++ b/sailfish/qml/components/videoplayer/VideoHud.qml
@@ -34,6 +34,8 @@ Item {
     property var manager
     property string title
     property bool _manuallyActivated: false
+    /// Don't allow the HUD to hide
+    property bool alwaysVisible: false
     readonly property bool hidden: opacity == 0.0
 
     Behavior on opacity { FadeAnimator {} }
@@ -174,6 +176,7 @@ Item {
     }
 
     function hide(manual) {
+        if (alwaysVisible) return
         // Don't hide if the user decided on their own to show the hud
         //if (!manual && _manuallyActivated) return;
         // Don't give in to the user if they want to hide the hud while it was forced upon them

--- a/sailfish/qml/harbour-sailfin.qml
+++ b/sailfish/qml/harbour-sailfin.qml
@@ -50,6 +50,7 @@ ApplicationWindow {
     ApiClient {
         id: _apiClient
         objectName: "Test"
+        appName: "Sailfin"
         supportedCommands: [GeneralCommandType.Play, GeneralCommandType.DisplayMessage]
     }
 

--- a/sailfish/qml/harbour-sailfin.qml
+++ b/sailfish/qml/harbour-sailfin.qml
@@ -75,7 +75,7 @@ ApplicationWindow {
     //cover: CoverBackground {CoverPlaceholder { icon.source: "icon.png"; text: "Sailfin"}}
     cover: {
         // Disabled due to buggy Loader behaviour
-        if ([MediaPlayer.NoMedia, MediaPlayer.InvalidMedia, MediaPlayer.UnknownStatus].indexOf(_playbackManager.mediaStatus) >= 0
+        if ([MediaStatus.NoMedia, MediaStatus.InvalidMedia].indexOf(_playbackManager.mediaStatus) >= 0
                  || _playbackManager.playbackState === MediaPlayer.StoppedState) {
             return Qt.resolvedUrl("cover/CollectionPage.qml")
         } else {
@@ -134,7 +134,9 @@ ApplicationWindow {
     }
 
     DisplayBlanking {
-        preventBlanking: playbackManager.playbackState === MediaPlayer.PlayingState && playbackManager.hasVideo
+        preventBlanking: playbackManager.playbackState === MediaPlayer.PlayingState
+                         && playbackManager.hasVideo
+                         && playbackManager.controllingSessionLocal // Must be controlling a local session
     }
     
     PlaybackBar {

--- a/sailfish/qml/harbour-sailfin.qml
+++ b/sailfish/qml/harbour-sailfin.qml
@@ -51,6 +51,7 @@ ApplicationWindow {
         id: _apiClient
         objectName: "Test"
         appName: "Sailfin"
+        deviceType: DeviceType.Phone
         supportedCommands: [GeneralCommandType.Play, GeneralCommandType.DisplayMessage]
     }
 

--- a/sailfish/qml/pages/ControllableDevicesPage.qml
+++ b/sailfish/qml/pages/ControllableDevicesPage.qml
@@ -34,7 +34,19 @@ Page {
                 }
                 height: parent.contentHeight - 2 * Theme.paddingMedium
                 width: height
-                source: "image://theme/icon-m-computer"
+                source: {
+                    if (model.deviceType == J.DeviceType.Phone) {
+                        return "image://theme/icon-m-device"
+                    } else if (model.deviceType == J.DeviceType.Tv) {
+                        // For the lack of a better icon
+                        return "image://theme/icon-m-device-landscape"
+                    } else if (model.deviceType == J.DeviceType.Computer) {
+                        return "image://theme/icon-m-computer"
+                    } else {
+                        //case J.DeviceType.Unknown:
+                        return "image://theme/icon-m-question"
+                    }
+                }
                 highlighted: parent.down || isConnected
             }
             Column {

--- a/sailfish/qml/pages/ControllableDevicesPage.qml
+++ b/sailfish/qml/pages/ControllableDevicesPage.qml
@@ -1,0 +1,63 @@
+import QtQuick 2.6
+import Sailfish.Silica 1.0
+
+import nl.netsoj.chris.Jellyfin 1.0 as J
+import ".."
+
+Page {
+    id: pageRoot
+    SilicaListView {
+        id: listView
+        anchors.fill: parent
+        contentHeight: Theme.itemSizeLarge
+
+        header: PageHeader {
+            //: Page title: page for remote controlling other Jellyfin apps
+            title: qsTr("Remote control")
+        }
+        model: J.RemoteDeviceList {
+            id: deviceList
+            apiClient: appWindow.apiClient
+            scanning: pageRoot.status == PageStatus.Active
+        }
+
+        delegate: ListItem {
+            property bool isConnected: model.jellyfinId === appWindow.playbackManager.controllingSessionId
+            onClicked: deviceList.activateSession(appWindow.playbackManager, model.index)
+            contentHeight: Theme.itemSizeMedium
+            HighlightImage {
+                id: deviceIcon
+                anchors {
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
+                    verticalCenter: parent.verticalCenter
+                }
+                height: parent.contentHeight - 2 * Theme.paddingMedium
+                width: height
+                source: "image://theme/icon-m-computer"
+                highlighted: parent.down || isConnected
+            }
+            Column {
+                anchors {
+                    left: deviceIcon.right
+                    right: parent.right
+                    verticalCenter: parent.verticalCenter
+                    leftMargin: Theme.paddingLarge
+                    rightMargin: Theme.horizontalPageMargin
+                }
+                Label {
+                    id: deviceName
+                    //: List of devices item title in the form of <app name> — <device name>
+                    text: qsTr("%1 — %2").arg(model.name).arg(model.deviceName)
+                    color: isConnected || highlighted ? Theme.highlightColor : Theme.primaryColor
+                }
+                Label {
+                    id: deviceUser
+                    text: model.userName
+                    color: isConnected || highlighted ? Theme.secondaryHighlightColor : Theme.secondaryColor
+                }
+            }
+        }
+    }
+
+}

--- a/sailfish/qml/pages/ControllableDevicesPage.qml
+++ b/sailfish/qml/pages/ControllableDevicesPage.qml
@@ -25,7 +25,7 @@ Page {
             property bool isConnected: model.jellyfinId === appWindow.playbackManager.controllingSessionId
             onClicked: deviceList.activateSession(appWindow.playbackManager, model.index)
             contentHeight: Theme.itemSizeMedium
-            HighlightImage {
+            Icon {
                 id: deviceIcon
                 anchors {
                     left: parent.left

--- a/sailfish/qml/pages/MainPage.qml
+++ b/sailfish/qml/pages/MainPage.qml
@@ -46,6 +46,11 @@ Page {
                 onClicked: pageStack.push(Qt.resolvedUrl("SettingsPage.qml"))
             }
             MenuItem {
+                //: Pulley menu item: shows controllable device page
+                text: qsTr("Remote control")
+                onClicked: pageStack.push(Qt.resolvedUrl("ControllableDevicesPage.qml"))
+            }
+            MenuItem {
                 //: Pulley menu item: reload items on page
                 text: qsTr("Reload")
                 onClicked: loadModels(true)

--- a/sailfish/qml/pages/VideoPage.qml
+++ b/sailfish/qml/pages/VideoPage.qml
@@ -38,7 +38,16 @@ Page {
     property int subtitleTrack
     property bool resume: true
 
-    allowedOrientations: Orientation.All
+    allowedOrientations: {
+        if (itemData.width !== null && itemData.height !== null) {
+            return itemData.width / itemData.height > Screen.width / Screen.height
+                             ? Orientation.LandscapeMask
+                             : Orientation.PortraitMask
+        } else {
+            return Orientation.All
+        }
+    }
+
     showNavigationIndicator: videoPlayer.hudVisible
 
     VideoPlayer {


### PR DESCRIPTION
* [x] Discovering other Jellyfin clients
* [x] Mirroring state from the controlled client
    * [x] Currently playing item
    * [x] PlayState (playback position, Play/Pause)
    * [x] Playlist/Queue
* [ ] Sending commands
    * [x] Play/Pause/Seek/Next/Previous
    * [x] Start playing an item
    * [x] Start playing an item in a playlist
        * [x] From the start
        * [x] From an offset
    * [ ] Send which item is being viewed 
    * [x] Send which subtitle stream and audio stream should be used
* [x] Swapping between local playback and controlling another device
    * [ ] Seamlessly transfer state between the current device and the controlled device (if it is not playing anything already)
* [x] UI tweaks
    * [x] Add a page to select the device to control
    * [x] Playing bar/Now playing screen
        * [x] Always show when controlling a remote device
        * [x] Show which device is being controlled 
        * [x] A better "Nothing Playing" state
    * [x] Don't go into an empty `VideoPage` when playing a video