### PR TITLE
Improve layout on larger screens

### DIFF
--- a/sailfish/qml/Constants.qml
+++ b/sailfish/qml/Constants.qml
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2020 Chris Josten
+Copyright (C) 2020-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -59,7 +59,8 @@ QtObject {
         }
     }
 
-    readonly property real libraryDelegatePosterHeight: libraryDelegateHeight * 1.5 // 1.6667
+    readonly property real libraryDelegatePosterRatio: 1.5
+    readonly property real libraryDelegatePosterHeight: libraryDelegateHeight * libraryDelegatePosterRatio
 
     readonly property real libraryProgressHeight: Theme.paddingMedium
 

--- a/sailfish/qml/Utils.js
+++ b/sailfish/qml/Utils.js
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2020 Chris Josten
+Copyright (C) 2020-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -52,7 +52,7 @@ function propsToQuery(options) {
     for (var prop in options) {
         if (options.hasOwnProperty(prop)) {
             var value = options[prop];
-            if (prop === "maxWidth" || prop === "maxHeight") {
+            if (prop === "maxWidth" || prop === "maxHeight" || prop === "width" || prop === "height") {
                 value = Math.floor(options[prop]);
             }
             query += "&" + prop + "=" + value;

--- a/sailfish/qml/components/PlayToolbar.qml
+++ b/sailfish/qml/components/PlayToolbar.qml
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2020 Chris Josten
+Copyright (C) 2020-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -26,12 +26,13 @@ Column {
     property real playProgress: 0.0
     property bool favourited: false
     property alias imageBlurhash: playImage.blurhash
+    property real maxHeight: parent.width / imageAspectRatio
     signal playPressed(bool resume)
     spacing: Theme.paddingLarge
 
     BackgroundItem {
         width: parent.width
-        height: width / imageAspectRatio
+        height: Math.min(maxHeight, width / imageAspectRatio)
         RemoteImage {
             id: playImage
             anchors.fill: parent

--- a/sailfish/qml/components/PlaybackBar.qml
+++ b/sailfish/qml/components/PlaybackBar.qml
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2021 Chris Josten
+Copyright (C) 2021-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -18,7 +18,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
 import QtQuick 2.6
-import QtMultimedia 5.6
 import Sailfish.Silica 1.0
 
 import nl.netsoj.chris.Jellyfin 1.0 as J
@@ -231,9 +230,9 @@ PanelBackground {
                 rightMargin: Theme.paddingMedium
                 verticalCenter: parent.verticalCenter
             }
-            icon.source: manager.playbackState === MediaPlayer.PlayingState
+            icon.source: manager.playbackState === J.PlayerState.Playing
                          ? "image://theme/icon-m-pause" : "image://theme/icon-m-play"
-            onClicked: manager.playbackState === MediaPlayer.PlayingState
+            onClicked: manager.playbackState === J.PlayerState.Playing
                 ? manager.pause()
                 : manager.play()
         }

--- a/sailfish/qml/pages/ConnectingPage.qml
+++ b/sailfish/qml/pages/ConnectingPage.qml
@@ -2,6 +2,8 @@ import QtQuick 2.0
 import Sailfish.Silica 1.0
 
 Page {
+    allowedOrientations: Orientation.All
+
     PageBusyIndicator {
         running: true
     }

--- a/sailfish/qml/pages/itemdetails/BaseDetailPage.qml
+++ b/sailfish/qml/pages/itemdetails/BaseDetailPage.qml
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2020 Chris Josten
+Copyright (C) 2020-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -39,6 +39,9 @@ Page {
     readonly property bool hasLogo: (typeof itemData.imageTags !== "undefined") && (typeof itemData.imageTags["Logo"] !== "undefined")
     property string _chosenBackdropImage: ""
     readonly property string parentId: itemData.parentId || ""
+
+    readonly property int gridColumnCount: Math.floor(pageRoot.width / Theme.itemSizeHuge)
+    readonly property int gridCellSize: Math.floor(pageRoot.width / gridColumnCount)
 
     function updateBackdrop() {
         /*var rand = 0;

--- a/sailfish/qml/pages/itemdetails/CollectionPage.qml
+++ b/sailfish/qml/pages/itemdetails/CollectionPage.qml
@@ -63,9 +63,9 @@ BaseDetailPage {
         id: gridView
         anchors.fill: parent
         model: collectionModel
-        cellWidth: Constants.libraryDelegateWidth
-        cellHeight: Utils.usePortraitCover(itemData.collectionType) ? Constants.libraryDelegatePosterHeight
-                                                                    : Constants.libraryDelegateHeight
+        cellWidth: gridCellSize
+        cellHeight: Utils.usePortraitCover(itemData.collectionType) ? gridCellSize * Constants.libraryDelegatePosterRatio
+                                                                    : gridCellSize
         visible: itemData.status !== J.LoaderBase.Error
 
         header: PageHeader {

--- a/sailfish/qml/pages/itemdetails/MusicAlbumPage.qml
+++ b/sailfish/qml/pages/itemdetails/MusicAlbumPage.qml
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2020 Chris Josten
+Copyright (C) 2020-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -29,10 +29,8 @@ import "../.."
 BaseDetailPage {
     id: albumPageRoot
     readonly property int _songIndexWidth: 100
-    width: 800 * Theme.pixelRatio
-
     property bool _collectionModelLoaded: false
-    readonly property bool _twoColumns: albumPageRoot.width / Theme.pixelRatio >= 800
+    readonly property bool _twoColumns: gridColumnCount > 4
     readonly property string _description: {
         if (itemData.type === "MusicAlbum") {
             //: Short description of the album: %1 -> album artist, %2 -> amount of songs, %3 -> duration, %4 -> release year
@@ -63,17 +61,7 @@ BaseDetailPage {
     RowLayout {
         anchors.fill: parent
 
-        Item {height: 1; width: Theme.horizontalPageMargin; visible: wideAlbumCover.visible; }
-        Loader {
-            id: wideAlbumCover
-            visible: _twoColumns
-            Layout.minimumWidth: 1000 / Theme.pixelRatio
-            Layout.fillHeight: true
-            source: visible
-                    ? "../../components/music/WideAlbumCover.qml" : ""
-            onLoaded: bindAlbum(item)
-        }
-        Item {height: 1; width: Theme.horizontalPageMargin; visible: wideAlbumCover.visible; }
+
         SilicaListView {
             id: list
             Layout.fillHeight: true
@@ -101,6 +89,17 @@ BaseDetailPage {
 
             VerticalScrollDecorator {}
         }
+        Item {height: 1; width: Theme.paddingLarge; visible: wideAlbumCover.visible; }
+        Loader {
+            id: wideAlbumCover
+            visible: _twoColumns
+            Layout.minimumWidth: gridCellSize * 2
+            Layout.fillHeight: true
+            source: visible
+                    ? "../../components/music/WideAlbumCover.qml" : ""
+            onLoaded: bindAlbum(item)
+        }
+        Item {height: 1; width: Theme.horizontalPageMargin; visible: wideAlbumCover.visible; }
     }
 
     function bindAlbum(item) {

--- a/sailfish/qml/pages/itemdetails/MusicArtistPage.qml
+++ b/sailfish/qml/pages/itemdetails/MusicArtistPage.qml
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2022 Chris Josten
+Copyright (C) 2022-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -107,7 +107,7 @@ BaseDetailPage {
                         left: parent.left
                         right: parent.right
                     }
-                    height: width / 16 * 9
+                    height: Math.min(albumPage.height / 2, width / 16 * 9)
                     fillMode: Image.PreserveAspectCrop
                     source: Utils.itemBackdropUrl(apiClient.baseUrl, itemData, 0, {"maxWidth": parent.width})
                     blurhash: itemData.imageBlurHashes["Backdrop"][itemData.backdropImageTags[0]]
@@ -219,15 +219,14 @@ BaseDetailPage {
                                                     "pageTitle": qsTr("Discography of %1").arg(itemData.name)
                                                 })
             }
+
             GridLayout {
-                width: parent.width
-                columns: 3
+                anchors.left: parent.left
+                width: Math.min(appearsOnModel.count() * gridCellSize, gridColumnCount * gridCellSize)
+                columns: gridColumnCount
                 columnSpacing: 0
                 rowSpacing: 0
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                }
+
                 Repeater {
                     id: albumRepeater
                     model: albumsModel
@@ -237,8 +236,8 @@ BaseDetailPage {
                         poster: Utils.itemModelImageUrl(appWindow.apiClient.baseUrl, model.jellyfinId, model.imageTags["Primary"], "Primary", {"height": height})
                         blurhash: model.imageBlurHashes["Primary"][model.imageTags["Primary"]]
                         title: model.name
-                        Layout.preferredWidth: Constants.libraryDelegateWidth * _multiplier
-                        Layout.preferredHeight: Constants.libraryDelegateHeight * _multiplier
+                        Layout.preferredWidth: gridCellSize * _multiplier
+                        Layout.preferredHeight: gridCellSize * _multiplier
                         Layout.rowSpan: _multiplier
                         Layout.columnSpan: _multiplier
                         onClicked:  appWindow.navigateToItem(model.jellyfinId, model.mediaType, model.type, model.isFolder)
@@ -256,14 +255,13 @@ BaseDetailPage {
                                                 })
             }
             GridLayout {
-                width: parent.width
-                columns: 3
+                anchors.left: parent.left
+                width: Math.min(appearsOnModel.count() * gridCellSize, gridColumnCount * gridCellSize)
+
+                columns: gridColumnCount
                 columnSpacing: 0
                 rowSpacing: 0
-                anchors {
-                    left: parent.left
-                    right: parent.right
-                }
+
                 Repeater {
                     id: appearsOnRepeater
                     model: appearsOnModel
@@ -274,8 +272,9 @@ BaseDetailPage {
                         blurhash: model.imageBlurHashes["Primary"][model.imageTags["Primary"]]
                         title: model.name
                         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-                        Layout.preferredWidth: Constants.libraryDelegateWidth * _multiplier
-                        Layout.preferredHeight: Constants.libraryDelegateHeight * _multiplier
+                        Layout.preferredWidth: gridCellSize * _multiplier
+                        Layout.maximumWidth: gridCellSize * _multiplier
+                        Layout.preferredHeight: gridCellSize * _multiplier
                         Layout.fillWidth: false
                         Layout.fillHeight: false
                         onClicked:  appWindow.navigateToItem(model.jellyfinId, model.mediaType, model.type, model.isFolder)

--- a/sailfish/qml/pages/itemdetails/SeasonPage.qml
+++ b/sailfish/qml/pages/itemdetails/SeasonPage.qml
@@ -1,6 +1,6 @@
 /*
 Sailfin: a Jellyfin client written using Qt
-Copyright (C) 2020 Chris Josten
+Copyright (C) 2020-2024 Chris Josten
 
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
@@ -58,7 +58,7 @@ BaseDetailPage {
                 id: episodeImage
                 anchors {
                     top: parent.top
-                    left: parent.left
+                    right: parent.right
                     bottom: parent.bottom
                 }
                 width: Constants.libraryDelegateWidth
@@ -116,11 +116,11 @@ BaseDetailPage {
             Label {
                 id: episodeTitle
                 anchors {
-                    left: episodeImage.right
-                    leftMargin: Theme.paddingLarge
+                    right: episodeImage.left
+                    rightMargin: Theme.paddingLarge
                     top: parent.top
-                    right: parent.right
-                    rightMargin: Theme.horizontalPageMargin
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
                 }
                 text: model.name
                 truncationMode: TruncationMode.Fade
@@ -130,10 +130,10 @@ BaseDetailPage {
             Label {
                 id: episodeOverview
                 anchors {
-                    left: episodeImage.right
-                    leftMargin: Theme.paddingLarge
-                    right: parent.right
-                    rightMargin: Theme.horizontalPageMargin
+                    right: episodeImage.left
+                    rightMargin: Theme.paddingLarge
+                    left: parent.left
+                    leftMargin: Theme.horizontalPageMargin
                     top: episodeTitle.bottom
                     bottom: parent.bottom
                 }

--- a/sailfish/qml/pages/itemdetails/VideoPage.qml
+++ b/sailfish/qml/pages/itemdetails/VideoPage.qml
@@ -63,6 +63,7 @@ BaseDetailPage {
                 imageSource: detailPage.imageSource
                 imageAspectRatio: Constants.horizontalVideoAspectRatio
                 imageBlurhash: detailPage.imageBlurhash
+                maxHeight: detailPage.height / 2
                 Binding on favourited {
                     when: _userdataReady
                     value: itemData.userData.favorite

--- a/sailfish/qml/pages/setup/LoginDialog.qml
+++ b/sailfish/qml/pages/setup/LoginDialog.qml
@@ -42,6 +42,7 @@ Dialog {
 
 
     acceptDestination: Page {
+        allowedOrientations: Orientation.All
         BusyLabel {
             text: qsTr("Logging in as %1").arg(username.text)
             running: true

--- a/sailfish/translations/harbour-sailfin-de.ts
+++ b/sailfish/translations/harbour-sailfin-de.ts
@@ -4,30 +4,36 @@
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../qml/pages/AboutPage.qml" line="38"/>
         <source>About Sailfin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Open externally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>LGPL 2.1 License</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="53"/>
         <source>&lt;p&gt;&lt;b&gt;Sailfin version %1&lt;/b&gt;&lt;br/&gt;Copyright © Chris Josten 2020–%2&lt;/p&gt;&lt;p&gt;Sailfin is Free Software licensed under the &lt;a href=&apos;lgpl&apos;&gt;LGPL-v2.1&lt;/a&gt; or later, at your choice. You can &lt;a href=&quot;github&quot;&gt;view its source code on GitHub&lt;/a&gt;. Parts of the code of Sailfin are from other libraries. &lt;a href=&apos;3rdparty&apos;&gt;View their licenses here&lt;/a&gt;.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/AboutPage.qml" line="79"/>
         <source>Contributors</source>
         <extracomment>SectionHeader</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="107"/>
+        <source>Open externally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="116"/>
+        <source>LGPL 2.1 License</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddServerConnectingPage</name>
     <message>
+        <location filename="../qml/pages/setup/AddServerConnectingPage.qml" line="37"/>
         <source>Connecting to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -35,30 +41,37 @@
 <context>
     <name>AddServerPage</name>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="50"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="51"/>
         <source>Connect to Jellyfin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="61"/>
         <source>Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="62"/>
         <source>Sailfin will try to search for Jellyfin servers on your local network automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="69"/>
         <source>enter address manually</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="107"/>
         <source>Server address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="108"/>
         <source>e.g. https://demo.jellyfin.org</source>
         <translation type="unfinished"></translation>
     </message>
@@ -66,10 +79,12 @@
 <context>
     <name>BaseDetailPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/BaseDetailPage.qml" line="72"/>
         <source>Retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/BaseDetailPage.qml" line="83"/>
         <source>An error has occured</source>
         <translation type="unfinished"></translation>
     </message>
@@ -77,106 +92,121 @@
 <context>
     <name>CollectionPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="72"/>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sort by</source>
-        <extracomment>Menu item for selecting the sort order of a collection</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty collection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add some items to this collection!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Play count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Date added</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ascending</source>
-        <extracomment>Sort order</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Descending</source>
-        <extracomment>Sort order</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sailfin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="79"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="84"/>
         <source>Remote control</source>
         <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="90"/>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="169"/>
+        <source>Sort by</source>
+        <extracomment>Menu item for selecting the sort order of a collection</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="144"/>
+        <source>Empty collection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="145"/>
+        <source>Add some items to this collection!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="160"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="161"/>
+        <source>Play count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="162"/>
+        <source>Date added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="185"/>
+        <source>Ascending</source>
+        <extracomment>Sort order</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="190"/>
+        <source>Descending</source>
+        <extracomment>Sort order</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/cover/CollectionPage.qml" line="124"/>
+        <source>Sailfin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ControllableDevicesPage</name>
     <message>
+        <location filename="../qml/pages/ControllableDevicesPage.qml" line="16"/>
         <source>Remote control</source>
         <extracomment>Page title: page for remote controlling other Jellyfin apps</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/ControllableDevicesPage.qml" line="63"/>
         <source>%1 — %2</source>
         <extracomment>List of devices item title in the form of &lt;app name&gt; — &lt;device name&gt;</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>CoverPage</name>
-    <message>
-        <source>My Cover</source>
-        <translation type="vanished">Mein Cover</translation>
-    </message>
-</context>
-<context>
     <name>DebugPage</name>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="47"/>
         <source>Debug information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="51"/>
         <source>Show debug information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="57"/>
         <source>Websocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="61"/>
         <source>Connection state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="67"/>
         <source>Unconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="95"/>
         <source>%1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="100"/>
         <source>Device profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -184,18 +214,22 @@
 <context>
     <name>EpisodePage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="30"/>
         <source>Episode %1–%2 | %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="34"/>
         <source>Episode %1 | %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="39"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="44"/>
         <source>No overview available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -203,40 +237,30 @@
 <context>
     <name>FilmPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/FilmPage.qml" line="29"/>
         <source>Released: %1 — Run time: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/FilmPage.qml" line="34"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>FirstPage</name>
-    <message>
-        <source>Show Page 2</source>
-        <translation type="vanished">Zur Seite 2</translation>
-    </message>
-    <message>
-        <source>UI Template</source>
-        <translation type="vanished">UI-Vorlage</translation>
-    </message>
-    <message>
-        <source>Hello Sailors</source>
-        <translation type="vanished">Hallo Matrosen</translation>
-    </message>
-</context>
-<context>
     <name>LegalPage</name>
     <message>
+        <location filename="../qml/pages/LegalPage.qml" line="55"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/LegalPage.qml" line="59"/>
         <source>Sailfin contains code taken from other projects. Without them, Sailfin would not be possible!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/LegalPage.qml" line="76"/>
         <source>This program contains small snippets of code taken from &lt;a href=&quot;%1&quot;&gt;%2&lt;/a&gt;, which is licensed under the %3 license:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -244,34 +268,41 @@
 <context>
     <name>LoginDialog</name>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="47"/>
         <source>Logging in as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="65"/>
         <source>Invalid username or password</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="85"/>
         <source>Login</source>
         <extracomment>Dialog action</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="129"/>
         <source>Credentials</source>
         <extracomment>Section header for entering username and password</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="136"/>
         <source>Username</source>
         <extracomment>Label placeholder for username field</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="154"/>
         <source>Password</source>
         <extracomment>Label placeholder for password field</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="176"/>
         <source>Login message</source>
         <extracomment>Message shown on login, configured by the server owner. Some form of a MOTD</extracomment>
         <translation type="unfinished"></translation>
@@ -280,56 +311,67 @@
 <context>
     <name>MainPage</name>
     <message>
+        <location filename="../qml/pages/MainPage.qml" line="45"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/MainPage.qml" line="50"/>
+        <source>Remote control</source>
+        <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="55"/>
         <source>Reload</source>
         <extracomment>Pulley menu item: reload items on page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/MainPage.qml" line="88"/>
         <source>Resume watching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/MainPage.qml" line="99"/>
         <source>Next up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/MainPage.qml" line="136"/>
         <source>Network error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/MainPage.qml" line="139"/>
         <source>Pull down to retry again</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remote control</source>
-        <extracomment>Pulley menu item: shows controllable device page</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MusicAlbumPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="37"/>
         <source>%1
 %2 songs | %3 | %4</source>
         <extracomment>Short description of the album: %1 -&gt; album artist, %2 -&gt; amount of songs, %3 -&gt; duration, %4 -&gt; release year</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="42"/>
         <source>Unknown year</source>
         <extracomment>Unknown album release year</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="44"/>
         <source>Playlist
 %1 songs | %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="78"/>
         <source>Disc %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -337,23 +379,28 @@
 <context>
     <name>MusicArtistPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="144"/>
         <source>%1 songs | %2 albums</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="213"/>
         <source>Discography</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="219"/>
         <source>Discography of %1</source>
         <extracomment>Page title for the page with an overview of all albums, eps and singles by a specific artist</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="248"/>
         <source>Appears on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="254"/>
         <source>%1 appears on</source>
         <extracomment>Page title for the page with an overview of all albums a specific artist appears on</extracomment>
         <translation type="unfinished"></translation>
@@ -362,56 +409,69 @@
 <context>
     <name>MusicLibraryPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="44"/>
+        <source>Settings</source>
+        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="49"/>
+        <source>Remote control</source>
+        <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="105"/>
         <source>Recently added</source>
         <extracomment>Header on music library: Recently added music albums</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="118"/>
         <source>Latest media</source>
         <extracomment>Page title for the list of all albums within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="125"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="140"/>
         <source>Albums</source>
         <extracomment>Page title for the list of all albums within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="145"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="160"/>
         <source>Playlists</source>
         <extracomment>Page title for the list of all playlists within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="166"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="179"/>
         <source>Artists</source>
         <extracomment>Header for music artists
 ----------
 Page title for the list of all artists within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Settings</source>
-        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remote control</source>
-        <extracomment>Pulley menu item: shows controllable device page</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>PlayQueue</name>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="17"/>
         <source>Queue</source>
         <extracomment>Now playing page queue section header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="20"/>
         <source>Playlist</source>
         <extracomment>Now playing page playlist section header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="22"/>
         <source>Unknown section: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -419,36 +479,43 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>PlaybackBar</name>
     <message>
-        <source>No audio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Shuffle not yet implemented</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Stop</source>
-        <extracomment>Pulley menu item: stops playback of music</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="135"/>
         <source>Nothing is playing</source>
         <extracomment>Shown in a bright font when no media is playing in the bottom bar and now playing screen</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="149"/>
         <source>Connected to %1</source>
         <extracomment>Shown when no media is being played, but the app is controlling another Jellyfin client %1 is the name of said client</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="151"/>
         <source>Start playing some media!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="174"/>
+        <source>No audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="210"/>
+        <source>Shuffle not yet implemented</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="497"/>
+        <source>Stop</source>
+        <extracomment>Pulley menu item: stops playback of music</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PosterCover</name>
     <message>
+        <location filename="../qml/cover/PosterCover.qml" line="81"/>
         <source>%1/%2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -456,6 +523,7 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../src/harbour-sailfin.cpp" line="53"/>
         <source>Sailfin</source>
         <extracomment>Application display name</extracomment>
         <translation type="unfinished"></translation>
@@ -464,6 +532,20 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>QuickConnectDialog</name>
     <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="36"/>
+        <source>Allow login</source>
+        <extracomment>Accept button on dialog for submitting a Quick Connect code</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="50"/>
+        <source>To log a device in with Quick Connect, select the Quick Connect button and enter the displayed code in the field below.</source>
+        <extracomment>Instructions on page that tells the user a bit about how Quick Connect works</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="56"/>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="59"/>
         <source>Quick Connect code</source>
         <extracomment>Label for textfield for entering the Quick Connect codeyy
 ----------
@@ -471,16 +553,7 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow login</source>
-        <extracomment>Accept button on dialog for submitting a Quick Connect code</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>To log a device in with Quick Connect, select the Quick Connect button and enter the displayed code in the field below.</source>
-        <extracomment>Instructions on page that tells the user a bit about how Quick Connect works</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="81"/>
         <source>The Quick Connect code was not accepted</source>
         <extracomment>Error message shown below the textfield when it is not connected</extracomment>
         <translation type="unfinished"></translation>
@@ -489,25 +562,16 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>SeasonPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/SeasonPage.qml" line="143"/>
         <source>No overview available</source>
         <extracomment>No overview/summary text of an episode available</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
-    <name>SecondPage</name>
-    <message>
-        <source>Nested Page</source>
-        <translation type="vanished">Unterseite</translation>
-    </message>
-    <message>
-        <source>Item</source>
-        <translation type="vanished">Element</translation>
-    </message>
-</context>
-<context>
     <name>SeriesPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/SeriesPage.qml" line="63"/>
         <source>Seasons</source>
         <extracomment>Seasons of a (TV) show</extracomment>
         <translation type="unfinished"></translation>
@@ -516,70 +580,84 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>SettingsPage</name>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="48"/>
         <source>Settings</source>
         <extracomment>Header of Settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="53"/>
         <source>Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Log out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Logging out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Other</source>
-        <extracomment>Other settings menu item</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Streaming settings</source>
-        <extracomment>Settings list item for settings related to streaming</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Debug information</source>
-        <extracomment>Debug information settings menu itemy</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Sailfin</source>
-        <extracomment>About Sailfin settings menu itemy</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="112"/>
         <source>Quick Connect</source>
         <extracomment>This is a name used by Jellyfin and seems to be untranslated in other languages</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="116"/>
+        <source>Log out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="117"/>
+        <source>Logging out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="123"/>
+        <source>Other</source>
+        <extracomment>Other settings menu item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="136"/>
         <source>Start page</source>
         <extracomment>Combo box label for selecting where the application should start</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="138"/>
         <source>Which page should be shown when the application starts?</source>
         <extracomment>Combo box description for selecting where the application should start</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="143"/>
         <source>All libraries (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="185"/>
+        <source>Streaming settings</source>
+        <extracomment>Settings list item for settings related to streaming</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="192"/>
+        <source>Debug information</source>
+        <extracomment>Debug information settings menu itemy</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="199"/>
+        <source>About Sailfin</source>
+        <extracomment>About Sailfin settings menu itemy</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SongDelegate</name>
     <message>
+        <location filename="../qml/components/music/SongDelegate.qml" line="119"/>
         <source>Go to %1</source>
         <extracomment>Context menu item for navigating to the artist of the selected track</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/music/SongDelegate.qml" line="122"/>
         <source>Go to artists</source>
         <extracomment>Context menu item for navigating to one of the artists of the selected track (opens submenu)</extracomment>
         <translation type="unfinished"></translation>
@@ -588,22 +666,27 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>StreamingPage</name>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="42"/>
         <source>Streaming settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="46"/>
         <source>Allow transcoding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="47"/>
         <source>If enabled, Sailfin may request the Jellyfin server to transcode media to a more suitable media format for this device. It is recommended to leave this enabled unless your server is weak.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="58"/>
         <source>%1 mbps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="61"/>
         <source>Maximum streaming bitrate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -611,28 +694,33 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>UnsupportedPage</name>
     <message>
-        <source>Item type (%1) unsupported</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fallback page for %2 not found either
-This is still an alpha version :)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="35"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="40"/>
         <source>Remote control</source>
         <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="47"/>
+        <source>Item type (%1) unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="48"/>
+        <source>Fallback page for %2 not found either
+This is still an alpha version :)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UserGridDelegate</name>
     <message>
+        <location filename="../qml/components/UserGridDelegate.qml" line="51"/>
         <source>Other account</source>
         <translation type="unfinished"></translation>
     </message>
@@ -640,41 +728,49 @@ This is still an alpha version :)</source>
 <context>
     <name>VideoError</name>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="50"/>
         <source>No error</source>
         <extracomment>Just to be complete if the application shows a video playback error when there&apos;s no error.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="54"/>
         <source>Resource allocation error</source>
         <extracomment>Video playback error: out of resources</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="58"/>
         <source>Video format unsupported</source>
         <extracomment>Video playback error: unsupported format/codec</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="62"/>
         <source>Network error</source>
         <extracomment>Video playback error: network error</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="66"/>
         <source>Access denied</source>
         <extracomment>Video playback error: access denied</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="70"/>
         <source>Media service missing</source>
         <extracomment>Video playback error: the media cannot be played because the media service could not be instantiated.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="89"/>
         <source>Retry</source>
         <extracomment>Button to retry loading a video after a failure</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="94"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -682,6 +778,7 @@ This is still an alpha version :)</source>
 <context>
     <name>VideoPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/VideoPage.qml" line="57"/>
         <source>Run time: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -689,18 +786,22 @@ This is still an alpha version :)</source>
 <context>
     <name>VideoTrackSelector</name>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="47"/>
         <source>Video track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="62"/>
         <source>Audio track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="77"/>
         <source>Subtitle track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="83"/>
         <source>Off</source>
         <extracomment>Value in ComboBox to disable subtitles</extracomment>
         <translation type="unfinished"></translation>
@@ -709,6 +810,7 @@ This is still an alpha version :)</source>
 <context>
     <name>harbour-sailfin</name>
     <message>
+        <location filename="../qml/harbour-sailfin.qml" line="101"/>
         <source>Sailfin</source>
         <extracomment>The application name for the notification</extracomment>
         <translation type="unfinished"></translation>

--- a/sailfish/translations/harbour-sailfin-ru.ts
+++ b/sailfish/translations/harbour-sailfin-ru.ts
@@ -1,147 +1,173 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ru_RU" sourcelanguage="en">
+<TS version="2.1">
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../qml/pages/AboutPage.qml" line="38"/>
         <source>About Sailfin</source>
-        <translation>О программе Sailfin</translation>
-    </message>
-    <message>
-        <source>Open externally</source>
-        <translation>Открыть внешним приложением</translation>
-    </message>
-    <message>
-        <source></source>
-        <translation>Лицензия LGPL 2.1</translation>
-    </message>
-    <message>
-        <source>LGPL 2.1 License</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/AboutPage.qml" line="53"/>
         <source>&lt;p&gt;&lt;b&gt;Sailfin version %1&lt;/b&gt;&lt;br/&gt;Copyright © Chris Josten 2020–%2&lt;/p&gt;&lt;p&gt;Sailfin is Free Software licensed under the &lt;a href=&apos;lgpl&apos;&gt;LGPL-v2.1&lt;/a&gt; or later, at your choice. You can &lt;a href=&quot;github&quot;&gt;view its source code on GitHub&lt;/a&gt;. Parts of the code of Sailfin are from other libraries. &lt;a href=&apos;3rdparty&apos;&gt;View their licenses here&lt;/a&gt;.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/AboutPage.qml" line="79"/>
         <source>Contributors</source>
         <extracomment>SectionHeader</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="107"/>
+        <source>Open externally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="116"/>
+        <source>LGPL 2.1 License</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddServerConnectingPage</name>
     <message>
+        <location filename="../qml/pages/setup/AddServerConnectingPage.qml" line="37"/>
         <source>Connecting to %1</source>
-        <translation>Соединяемся с %1</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddServerPage</name>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="50"/>
         <source>Connect</source>
-        <translation>Соединиться</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="51"/>
         <source>Connect to Jellyfin</source>
-        <translation>Соединиться с Jellyfin</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="61"/>
         <source>Server</source>
-        <translation>Сервер</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="62"/>
         <source>Sailfin will try to search for Jellyfin servers on your local network automatically</source>
-        <translation>Sailfin попробует найти серверы Jellyfin в локальной сети автоматически</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="69"/>
         <source>enter address manually</source>
-        <translation>ввести адрес вручную</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="107"/>
         <source>Server address</source>
-        <translation>Адрес сервера</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="108"/>
         <source>e.g. https://demo.jellyfin.org</source>
-        <translation>Напр. https://demo.jellyfin.org</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>BaseDetailPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/BaseDetailPage.qml" line="72"/>
         <source>Retry</source>
-        <translation>Попробовать снова</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/BaseDetailPage.qml" line="83"/>
         <source>An error has occured</source>
-        <translation>Произошла ошибка</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>CollectionPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="72"/>
         <source>Loading</source>
-        <translation>Загрузка</translation>
-    </message>
-    <message>
-        <source>Sort by</source>
-        <extracomment>Menu item for selecting the sort order of a collection</extracomment>
-        <translation>Сортировка</translation>
-    </message>
-    <message>
-        <source>Empty collection</source>
-        <translation>Пустая коллекция</translation>
-    </message>
-    <message>
-        <source>Add some items to this collection!</source>
-        <translation>Добавьте что-то в эту коллекцию!</translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation>Название</translation>
-    </message>
-    <message>
-        <source>Play count</source>
-        <translation>Количество проигрываний</translation>
-    </message>
-    <message>
-        <source>Date added</source>
-        <translation>Дата добавления</translation>
-    </message>
-    <message>
-        <source>Ascending</source>
-        <extracomment>Sort order</extracomment>
-        <translation>По возрастанию</translation>
-    </message>
-    <message>
-        <source>Descending</source>
-        <extracomment>Sort order</extracomment>
-        <translation>По убыванию</translation>
-    </message>
-    <message>
-        <source>Sailfin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="79"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
-        <translation type="unfinished">Настройки</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="84"/>
         <source>Remote control</source>
         <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="90"/>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="169"/>
+        <source>Sort by</source>
+        <extracomment>Menu item for selecting the sort order of a collection</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="144"/>
+        <source>Empty collection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="145"/>
+        <source>Add some items to this collection!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="160"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="161"/>
+        <source>Play count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="162"/>
+        <source>Date added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="185"/>
+        <source>Ascending</source>
+        <extracomment>Sort order</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="190"/>
+        <source>Descending</source>
+        <extracomment>Sort order</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/cover/CollectionPage.qml" line="124"/>
+        <source>Sailfin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ControllableDevicesPage</name>
     <message>
+        <location filename="../qml/pages/ControllableDevicesPage.qml" line="16"/>
         <source>Remote control</source>
         <extracomment>Page title: page for remote controlling other Jellyfin apps</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/ControllableDevicesPage.qml" line="63"/>
         <source>%1 — %2</source>
         <extracomment>List of devices item title in the form of &lt;app name&gt; — &lt;device name&gt;</extracomment>
         <translation type="unfinished"></translation>
@@ -150,30 +176,37 @@
 <context>
     <name>DebugPage</name>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="47"/>
         <source>Debug information</source>
-        <translation>Отладочная информация</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="51"/>
         <source>Show debug information</source>
-        <translation>Показывать отладочную информацию</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="57"/>
         <source>Websocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="61"/>
         <source>Connection state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="67"/>
         <source>Unconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="95"/>
         <source>%1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="100"/>
         <source>Device profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -181,266 +214,308 @@
 <context>
     <name>EpisodePage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="30"/>
         <source>Episode %1–%2 | %3</source>
-        <translation>Серия %1–%2 | %3</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="34"/>
         <source>Episode %1 | %2</source>
-        <translation>Серия %1 | %2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="39"/>
         <source>Overview</source>
-        <translation>Описание</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="44"/>
         <source>No overview available</source>
-        <translation>Нет описания</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>FilmPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/FilmPage.qml" line="29"/>
         <source>Released: %1 — Run time: %2</source>
-        <translation>Вышел: %1 — Длительность: %2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/FilmPage.qml" line="34"/>
         <source>Overview</source>
-        <translation>Описание</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LegalPage</name>
     <message>
+        <location filename="../qml/pages/LegalPage.qml" line="55"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This program contains small snippets of code taken from &lt;a href=&quot;%1&quot;&gt;%2&lt;/a&gt;, which is licensed under the %3 license:</source>
+        <location filename="../qml/pages/LegalPage.qml" line="59"/>
+        <source>Sailfin contains code taken from other projects. Without them, Sailfin would not be possible!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sailfin contains code taken from other projects. Without them, Sailfin would not be possible!</source>
+        <location filename="../qml/pages/LegalPage.qml" line="76"/>
+        <source>This program contains small snippets of code taken from &lt;a href=&quot;%1&quot;&gt;%2&lt;/a&gt;, which is licensed under the %3 license:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LoginDialog</name>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="47"/>
         <source>Logging in as %1</source>
-        <translation>Входим как %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="65"/>
+        <source>Invalid username or password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="85"/>
         <source>Login</source>
         <extracomment>Dialog action</extracomment>
-        <translation>Войти</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="129"/>
         <source>Credentials</source>
         <extracomment>Section header for entering username and password</extracomment>
-        <translation>Учетные данные</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="136"/>
         <source>Username</source>
         <extracomment>Label placeholder for username field</extracomment>
-        <translation>Имя пользователя</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="154"/>
         <source>Password</source>
         <extracomment>Label placeholder for password field</extracomment>
-        <translation>Пароль</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="176"/>
         <source>Login message</source>
         <extracomment>Message shown on login, configured by the server owner. Some form of a MOTD</extracomment>
-        <translation>Сообщение при входе</translation>
-    </message>
-    <message>
-        <source>Invalid username or password</source>
-        <translation>Неверное имя пользователя или пароль</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <source>Resume watching</source>
-        <translation>Продолжить просмотр</translation>
-    </message>
-    <message>
-        <source>Next up</source>
-        <translation>Продолжения</translation>
-    </message>
-    <message>
-        <source>Network error</source>
-        <translation>Ошибка сети</translation>
-    </message>
-    <message>
-        <source>Pull down to retry again</source>
-        <translation>Потяните вниз чтобы попробовать снова</translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/MainPage.qml" line="45"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
-        <translation>Настройки</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Reload</source>
-        <extracomment>Pulley menu item: reload items on page</extracomment>
-        <translation>Обновить</translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/MainPage.qml" line="50"/>
         <source>Remote control</source>
         <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="55"/>
+        <source>Reload</source>
+        <extracomment>Pulley menu item: reload items on page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="88"/>
+        <source>Resume watching</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="99"/>
+        <source>Next up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="136"/>
+        <source>Network error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="139"/>
+        <source>Pull down to retry again</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MusicAlbumPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="37"/>
         <source>%1
 %2 songs | %3 | %4</source>
         <extracomment>Short description of the album: %1 -&gt; album artist, %2 -&gt; amount of songs, %3 -&gt; duration, %4 -&gt; release year</extracomment>
-        <translation>%1
-%2 песен | %3 | %4</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="42"/>
         <source>Unknown year</source>
         <extracomment>Unknown album release year</extracomment>
-        <translation>Неизвестный год</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="44"/>
         <source>Playlist
 %1 songs | %2</source>
-        <translation>Плейлист
-%1 песни | %2</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="78"/>
         <source>Disc %1</source>
-        <translation>Диск %1</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MusicArtistPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="144"/>
         <source>%1 songs | %2 albums</source>
-        <translation>%1 песен | %2 альбомов</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="213"/>
         <source>Discography</source>
-        <translation>Дискография</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="219"/>
         <source>Discography of %1</source>
         <extracomment>Page title for the page with an overview of all albums, eps and singles by a specific artist</extracomment>
-        <translation>Дискография %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="248"/>
         <source>Appears on</source>
-        <translation>Появляется на</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="254"/>
         <source>%1 appears on</source>
         <extracomment>Page title for the page with an overview of all albums a specific artist appears on</extracomment>
-        <translation>%1 появляется на</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MusicLibraryPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="44"/>
+        <source>Settings</source>
+        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="49"/>
+        <source>Remote control</source>
+        <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="105"/>
         <source>Recently added</source>
         <extracomment>Header on music library: Recently added music albums</extracomment>
-        <translation>Добавлены недавно</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="118"/>
         <source>Latest media</source>
         <extracomment>Page title for the list of all albums within the music library</extracomment>
-        <translation>Самые новые песни</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="125"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="140"/>
         <source>Albums</source>
         <extracomment>Page title for the list of all albums within the music library</extracomment>
-        <translation>Альбомы</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="145"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="160"/>
         <source>Playlists</source>
         <extracomment>Page title for the list of all playlists within the music library</extracomment>
-        <translation>Плейлисты</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="166"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="179"/>
         <source>Artists</source>
         <extracomment>Header for music artists
 ----------
 Page title for the list of all artists within the music library</extracomment>
-        <translation>Исполнители</translation>
-    </message>
-    <message>
-        <source>Settings</source>
-        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
-        <translation type="unfinished">Настройки</translation>
-    </message>
-    <message>
-        <source>Remote control</source>
-        <extracomment>Pulley menu item: shows controllable device page</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PlayQueue</name>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="17"/>
         <source>Queue</source>
         <extracomment>Now playing page queue section header</extracomment>
-        <translation>Очередь</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="20"/>
         <source>Playlist</source>
         <extracomment>Now playing page playlist section header</extracomment>
-        <translation>Плейлист</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="22"/>
         <source>Unknown section: %1</source>
-        <translation>Неизвестная секция: %1</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PlaybackBar</name>
     <message>
-        <source>No media selected</source>
-        <translation type="vanished">Ничего не выбрано</translation>
-    </message>
-    <message>
-        <source>Play some media!</source>
-        <translation type="vanished">Начните что-то проигрывать!</translation>
-    </message>
-    <message>
-        <source>No audio</source>
-        <translation>Нет звука</translation>
-    </message>
-    <message>
-        <source>Shuffle not yet implemented</source>
-        <translation>Перемешивание ещё не работает</translation>
-    </message>
-    <message>
-        <source>Stop</source>
-        <extracomment>Pulley menu item: stops playback of music</extracomment>
-        <translation>Стоп</translation>
-    </message>
-    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="135"/>
         <source>Nothing is playing</source>
         <extracomment>Shown in a bright font when no media is playing in the bottom bar and now playing screen</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="149"/>
         <source>Connected to %1</source>
         <extracomment>Shown when no media is being played, but the app is controlling another Jellyfin client %1 is the name of said client</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="151"/>
         <source>Start playing some media!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="174"/>
+        <source>No audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="210"/>
+        <source>Shuffle not yet implemented</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="497"/>
+        <source>Stop</source>
+        <extracomment>Pulley menu item: stops playback of music</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PosterCover</name>
     <message>
+        <location filename="../qml/cover/PosterCover.qml" line="81"/>
         <source>%1/%2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -448,6 +523,7 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../src/harbour-sailfin.cpp" line="53"/>
         <source>Sailfin</source>
         <extracomment>Application display name</extracomment>
         <translation type="unfinished"></translation>
@@ -456,6 +532,20 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>QuickConnectDialog</name>
     <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="36"/>
+        <source>Allow login</source>
+        <extracomment>Accept button on dialog for submitting a Quick Connect code</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="50"/>
+        <source>To log a device in with Quick Connect, select the Quick Connect button and enter the displayed code in the field below.</source>
+        <extracomment>Instructions on page that tells the user a bit about how Quick Connect works</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="56"/>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="59"/>
         <source>Quick Connect code</source>
         <extracomment>Label for textfield for entering the Quick Connect codeyy
 ----------
@@ -463,16 +553,7 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow login</source>
-        <extracomment>Accept button on dialog for submitting a Quick Connect code</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>To log a device in with Quick Connect, select the Quick Connect button and enter the displayed code in the field below.</source>
-        <extracomment>Instructions on page that tells the user a bit about how Quick Connect works</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="81"/>
         <source>The Quick Connect code was not accepted</source>
         <extracomment>Error message shown below the textfield when it is not connected</extracomment>
         <translation type="unfinished"></translation>
@@ -481,181 +562,215 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>SeasonPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/SeasonPage.qml" line="143"/>
         <source>No overview available</source>
         <extracomment>No overview/summary text of an episode available</extracomment>
-        <translation>Нет описания</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SeriesPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/SeriesPage.qml" line="63"/>
         <source>Seasons</source>
         <extracomment>Seasons of a (TV) show</extracomment>
-        <translation>Сезоны</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SettingsPage</name>
     <message>
-        <source>Other</source>
-        <extracomment>Other settings menu item</extracomment>
-        <translation>Другие</translation>
-    </message>
-    <message>
-        <source>About Sailfin</source>
-        <extracomment>About Sailfin settings menu itemy</extracomment>
-        <translation>О программе Sailfin</translation>
-    </message>
-    <message>
-        <source>Session</source>
-        <translation>Сессия</translation>
-    </message>
-    <message>
-        <source>Log out</source>
-        <translation>Выйти</translation>
-    </message>
-    <message>
-        <source>Logging out</source>
-        <translation>Выходим</translation>
-    </message>
-    <message>
-        <source>Debug information</source>
-        <extracomment>Debug information settings menu itemy</extracomment>
-        <translation>Отладочная информация</translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="48"/>
         <source>Settings</source>
         <extracomment>Header of Settings page</extracomment>
-        <translation>Настройки</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Streaming settings</source>
-        <extracomment>Settings list item for settings related to streaming</extracomment>
-        <translation>Настройки стриминга</translation>
+        <location filename="../qml/pages/SettingsPage.qml" line="53"/>
+        <source>Session</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="112"/>
         <source>Quick Connect</source>
         <extracomment>This is a name used by Jellyfin and seems to be untranslated in other languages</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="116"/>
+        <source>Log out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="117"/>
+        <source>Logging out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="123"/>
+        <source>Other</source>
+        <extracomment>Other settings menu item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="136"/>
         <source>Start page</source>
         <extracomment>Combo box label for selecting where the application should start</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="138"/>
         <source>Which page should be shown when the application starts?</source>
         <extracomment>Combo box description for selecting where the application should start</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="143"/>
         <source>All libraries (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="185"/>
+        <source>Streaming settings</source>
+        <extracomment>Settings list item for settings related to streaming</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="192"/>
+        <source>Debug information</source>
+        <extracomment>Debug information settings menu itemy</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="199"/>
+        <source>About Sailfin</source>
+        <extracomment>About Sailfin settings menu itemy</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SongDelegate</name>
     <message>
+        <location filename="../qml/components/music/SongDelegate.qml" line="119"/>
         <source>Go to %1</source>
         <extracomment>Context menu item for navigating to the artist of the selected track</extracomment>
-        <translation>Перейти к %1</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/music/SongDelegate.qml" line="122"/>
         <source>Go to artists</source>
         <extracomment>Context menu item for navigating to one of the artists of the selected track (opens submenu)</extracomment>
-        <translation>Перейти к исполнителям</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>StreamingPage</name>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="42"/>
         <source>Streaming settings</source>
-        <translation>Настройки стриминга</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="46"/>
         <source>Allow transcoding</source>
-        <translation>Разрешить транскодинг</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="47"/>
         <source>If enabled, Sailfin may request the Jellyfin server to transcode media to a more suitable media format for this device. It is recommended to leave this enabled unless your server is weak.</source>
-        <translation>Если включено, Sailfin может попросить сервер Jellyfin перекодировать медиафайл в более подходящий формат для устройства. Рекомендуется оставить это включенным, если ваш сервер не слишком слабый.</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="58"/>
         <source>%1 mbps</source>
-        <translation>%1 мегабит/сек</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="61"/>
         <source>Maximum streaming bitrate</source>
-        <translation>Максимальный битрейт стриминга</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UnsupportedPage</name>
     <message>
-        <source>Item type (%1) unsupported</source>
-        <translation>Тип файла (%1) не поддерживается</translation>
-    </message>
-    <message>
-        <source>Fallback page for %2 not found either
-This is still an alpha version :)</source>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="35"/>
+        <source>Settings</source>
+        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Settings</source>
-        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
-        <translation type="unfinished">Настройки</translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="40"/>
         <source>Remote control</source>
         <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="47"/>
+        <source>Item type (%1) unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="48"/>
+        <source>Fallback page for %2 not found either
+This is still an alpha version :)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UserGridDelegate</name>
     <message>
+        <location filename="../qml/components/UserGridDelegate.qml" line="51"/>
         <source>Other account</source>
-        <translation>Другая учетная запись</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>VideoError</name>
     <message>
-        <source>Resource allocation error</source>
-        <extracomment>Video playback error: out of resources</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Video format unsupported</source>
-        <extracomment>Video playback error: unsupported format/codec</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Network error</source>
-        <extracomment>Video playback error: network error</extracomment>
-        <translation type="unfinished">Ошибка сети</translation>
-    </message>
-    <message>
-        <source>Access denied</source>
-        <extracomment>Video playback error: access denied</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Media service missing</source>
-        <extracomment>Video playback error: the media cannot be played because the media service could not be instantiated.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Retry</source>
-        <extracomment>Button to retry loading a video after a failure</extracomment>
-        <translation type="unfinished">Попробовать снова</translation>
-    </message>
-    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="50"/>
         <source>No error</source>
         <extracomment>Just to be complete if the application shows a video playback error when there&apos;s no error.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="54"/>
+        <source>Resource allocation error</source>
+        <extracomment>Video playback error: out of resources</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="58"/>
+        <source>Video format unsupported</source>
+        <extracomment>Video playback error: unsupported format/codec</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="62"/>
+        <source>Network error</source>
+        <extracomment>Video playback error: network error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="66"/>
+        <source>Access denied</source>
+        <extracomment>Video playback error: access denied</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="70"/>
+        <source>Media service missing</source>
+        <extracomment>Video playback error: the media cannot be played because the media service could not be instantiated.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="89"/>
+        <source>Retry</source>
+        <extracomment>Button to retry loading a video after a failure</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="94"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -663,33 +778,39 @@ This is still an alpha version :)</source>
 <context>
     <name>VideoPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/VideoPage.qml" line="57"/>
         <source>Run time: %2</source>
-        <translation>Длительность: %2</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>VideoTrackSelector</name>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="47"/>
+        <source>Video track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="62"/>
         <source>Audio track</source>
-        <translation>Аудиодорожка</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="77"/>
         <source>Subtitle track</source>
-        <translation>Дорожка субтитров</translation>
+        <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="83"/>
         <source>Off</source>
         <extracomment>Value in ComboBox to disable subtitles</extracomment>
-        <translation>Выключено</translation>
-    </message>
-    <message>
-        <source>Video track</source>
-        <translation>Видеодорожка</translation>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>harbour-sailfin</name>
     <message>
+        <location filename="../qml/harbour-sailfin.qml" line="101"/>
         <source>Sailfin</source>
         <extracomment>The application name for the notification</extracomment>
         <translation type="unfinished"></translation>

--- a/sailfish/translations/harbour-sailfin.ts
+++ b/sailfish/translations/harbour-sailfin.ts
@@ -4,30 +4,36 @@
 <context>
     <name>AboutPage</name>
     <message>
+        <location filename="../qml/pages/AboutPage.qml" line="38"/>
         <source>About Sailfin</source>
-        <translation>About Sailfin</translation>
-    </message>
-    <message>
-        <source>Open externally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>LGPL 2.1 License</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="53"/>
         <source>&lt;p&gt;&lt;b&gt;Sailfin version %1&lt;/b&gt;&lt;br/&gt;Copyright © Chris Josten 2020–%2&lt;/p&gt;&lt;p&gt;Sailfin is Free Software licensed under the &lt;a href=&apos;lgpl&apos;&gt;LGPL-v2.1&lt;/a&gt; or later, at your choice. You can &lt;a href=&quot;github&quot;&gt;view its source code on GitHub&lt;/a&gt;. Parts of the code of Sailfin are from other libraries. &lt;a href=&apos;3rdparty&apos;&gt;View their licenses here&lt;/a&gt;.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/AboutPage.qml" line="79"/>
         <source>Contributors</source>
         <extracomment>SectionHeader</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="107"/>
+        <source>Open externally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/AboutPage.qml" line="116"/>
+        <source>LGPL 2.1 License</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>AddServerConnectingPage</name>
     <message>
+        <location filename="../qml/pages/setup/AddServerConnectingPage.qml" line="37"/>
         <source>Connecting to %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -35,30 +41,37 @@
 <context>
     <name>AddServerPage</name>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="50"/>
         <source>Connect</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="51"/>
         <source>Connect to Jellyfin</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="61"/>
         <source>Server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="62"/>
         <source>Sailfin will try to search for Jellyfin servers on your local network automatically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="69"/>
         <source>enter address manually</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="107"/>
         <source>Server address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/AddServerPage.qml" line="108"/>
         <source>e.g. https://demo.jellyfin.org</source>
         <translation type="unfinished"></translation>
     </message>
@@ -66,10 +79,12 @@
 <context>
     <name>BaseDetailPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/BaseDetailPage.qml" line="72"/>
         <source>Retry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/BaseDetailPage.qml" line="83"/>
         <source>An error has occured</source>
         <translation type="unfinished"></translation>
     </message>
@@ -77,67 +92,82 @@
 <context>
     <name>CollectionPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="72"/>
         <source>Loading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sort by</source>
-        <extracomment>Menu item for selecting the sort order of a collection</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Empty collection</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Add some items to this collection!</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Name</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Play count</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Date added</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Ascending</source>
-        <extracomment>Sort order</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Descending</source>
-        <extracomment>Sort order</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Sailfin</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="79"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="84"/>
         <source>Remote control</source>
         <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="90"/>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="169"/>
+        <source>Sort by</source>
+        <extracomment>Menu item for selecting the sort order of a collection</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="144"/>
+        <source>Empty collection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="145"/>
+        <source>Add some items to this collection!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="160"/>
+        <source>Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="161"/>
+        <source>Play count</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="162"/>
+        <source>Date added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="185"/>
+        <source>Ascending</source>
+        <extracomment>Sort order</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/CollectionPage.qml" line="190"/>
+        <source>Descending</source>
+        <extracomment>Sort order</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/cover/CollectionPage.qml" line="124"/>
+        <source>Sailfin</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ControllableDevicesPage</name>
     <message>
+        <location filename="../qml/pages/ControllableDevicesPage.qml" line="16"/>
         <source>Remote control</source>
         <extracomment>Page title: page for remote controlling other Jellyfin apps</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/ControllableDevicesPage.qml" line="63"/>
         <source>%1 — %2</source>
         <extracomment>List of devices item title in the form of &lt;app name&gt; — &lt;device name&gt;</extracomment>
         <translation type="unfinished"></translation>
@@ -146,30 +176,37 @@
 <context>
     <name>DebugPage</name>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="47"/>
         <source>Debug information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="51"/>
         <source>Show debug information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="57"/>
         <source>Websocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="61"/>
         <source>Connection state</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="67"/>
         <source>Unconnected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="95"/>
         <source>%1 (%2)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/DebugPage.qml" line="100"/>
         <source>Device profile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -177,18 +214,22 @@
 <context>
     <name>EpisodePage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="30"/>
         <source>Episode %1–%2 | %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="34"/>
         <source>Episode %1 | %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="39"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/EpisodePage.qml" line="44"/>
         <source>No overview available</source>
         <translation type="unfinished"></translation>
     </message>
@@ -196,10 +237,12 @@
 <context>
     <name>FilmPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/FilmPage.qml" line="29"/>
         <source>Released: %1 — Run time: %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/FilmPage.qml" line="34"/>
         <source>Overview</source>
         <translation type="unfinished"></translation>
     </message>
@@ -207,107 +250,128 @@
 <context>
     <name>LegalPage</name>
     <message>
+        <location filename="../qml/pages/LegalPage.qml" line="55"/>
         <source>Legal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>This program contains small snippets of code taken from &lt;a href=&quot;%1&quot;&gt;%2&lt;/a&gt;, which is licensed under the %3 license:</source>
+        <location filename="../qml/pages/LegalPage.qml" line="59"/>
+        <source>Sailfin contains code taken from other projects. Without them, Sailfin would not be possible!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Sailfin contains code taken from other projects. Without them, Sailfin would not be possible!</source>
+        <location filename="../qml/pages/LegalPage.qml" line="76"/>
+        <source>This program contains small snippets of code taken from &lt;a href=&quot;%1&quot;&gt;%2&lt;/a&gt;, which is licensed under the %3 license:</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LoginDialog</name>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="47"/>
         <source>Logging in as %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="65"/>
+        <source>Invalid username or password</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="85"/>
         <source>Login</source>
         <extracomment>Dialog action</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="129"/>
         <source>Credentials</source>
         <extracomment>Section header for entering username and password</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="136"/>
         <source>Username</source>
         <extracomment>Label placeholder for username field</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="154"/>
         <source>Password</source>
         <extracomment>Label placeholder for password field</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/setup/LoginDialog.qml" line="176"/>
         <source>Login message</source>
         <extracomment>Message shown on login, configured by the server owner. Some form of a MOTD</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Invalid username or password</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MainPage</name>
     <message>
-        <source>Resume watching</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Next up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/MainPage.qml" line="45"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Network error</source>
+        <location filename="../qml/pages/MainPage.qml" line="50"/>
+        <source>Remote control</source>
+        <extracomment>Pulley menu item: shows controllable device page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/MainPage.qml" line="55"/>
         <source>Reload</source>
         <extracomment>Pulley menu item: reload items on page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Pull down to retry again</source>
+        <location filename="../qml/pages/MainPage.qml" line="88"/>
+        <source>Resume watching</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Remote control</source>
-        <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <location filename="../qml/pages/MainPage.qml" line="99"/>
+        <source>Next up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="136"/>
+        <source>Network error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/MainPage.qml" line="139"/>
+        <source>Pull down to retry again</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>MusicAlbumPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="37"/>
         <source>%1
 %2 songs | %3 | %4</source>
         <extracomment>Short description of the album: %1 -&gt; album artist, %2 -&gt; amount of songs, %3 -&gt; duration, %4 -&gt; release year</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="42"/>
         <source>Unknown year</source>
         <extracomment>Unknown album release year</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="44"/>
         <source>Playlist
 %1 songs | %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicAlbumPage.qml" line="78"/>
         <source>Disc %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -315,23 +379,28 @@
 <context>
     <name>MusicArtistPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="144"/>
         <source>%1 songs | %2 albums</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="213"/>
         <source>Discography</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="219"/>
         <source>Discography of %1</source>
         <extracomment>Page title for the page with an overview of all albums, eps and singles by a specific artist</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="248"/>
         <source>Appears on</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicArtistPage.qml" line="254"/>
         <source>%1 appears on</source>
         <extracomment>Page title for the page with an overview of all albums a specific artist appears on</extracomment>
         <translation type="unfinished"></translation>
@@ -340,56 +409,69 @@
 <context>
     <name>MusicLibraryPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="44"/>
+        <source>Settings</source>
+        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="49"/>
+        <source>Remote control</source>
+        <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="105"/>
         <source>Recently added</source>
         <extracomment>Header on music library: Recently added music albums</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="118"/>
         <source>Latest media</source>
         <extracomment>Page title for the list of all albums within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="125"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="140"/>
         <source>Albums</source>
         <extracomment>Page title for the list of all albums within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="145"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="160"/>
         <source>Playlists</source>
         <extracomment>Page title for the list of all playlists within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="166"/>
+        <location filename="../qml/pages/itemdetails/MusicLibraryPage.qml" line="179"/>
         <source>Artists</source>
         <extracomment>Header for music artists
 ----------
 Page title for the list of all artists within the music library</extracomment>
         <translation type="unfinished"></translation>
     </message>
-    <message>
-        <source>Settings</source>
-        <extracomment>Pulley menu item: navigate to application settings page</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remote control</source>
-        <extracomment>Pulley menu item: shows controllable device page</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
 </context>
 <context>
     <name>PlayQueue</name>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="17"/>
         <source>Queue</source>
         <extracomment>Now playing page queue section header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="20"/>
         <source>Playlist</source>
         <extracomment>Now playing page playlist section header</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlayQueue.qml" line="22"/>
         <source>Unknown section: %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -397,36 +479,43 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>PlaybackBar</name>
     <message>
-        <source>No audio</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Shuffle not yet implemented</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Stop</source>
-        <extracomment>Pulley menu item: stops playback of music</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="135"/>
         <source>Nothing is playing</source>
         <extracomment>Shown in a bright font when no media is playing in the bottom bar and now playing screen</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="149"/>
         <source>Connected to %1</source>
         <extracomment>Shown when no media is being played, but the app is controlling another Jellyfin client %1 is the name of said client</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="151"/>
         <source>Start playing some media!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="174"/>
+        <source>No audio</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="210"/>
+        <source>Shuffle not yet implemented</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/PlaybackBar.qml" line="497"/>
+        <source>Stop</source>
+        <extracomment>Pulley menu item: stops playback of music</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>PosterCover</name>
     <message>
+        <location filename="../qml/cover/PosterCover.qml" line="81"/>
         <source>%1/%2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -434,6 +523,7 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../src/harbour-sailfin.cpp" line="53"/>
         <source>Sailfin</source>
         <extracomment>Application display name</extracomment>
         <translation type="unfinished"></translation>
@@ -442,6 +532,20 @@ Page title for the list of all artists within the music library</extracomment>
 <context>
     <name>QuickConnectDialog</name>
     <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="36"/>
+        <source>Allow login</source>
+        <extracomment>Accept button on dialog for submitting a Quick Connect code</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="50"/>
+        <source>To log a device in with Quick Connect, select the Quick Connect button and enter the displayed code in the field below.</source>
+        <extracomment>Instructions on page that tells the user a bit about how Quick Connect works</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="56"/>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="59"/>
         <source>Quick Connect code</source>
         <extracomment>Label for textfield for entering the Quick Connect codeyy
 ----------
@@ -449,16 +553,7 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow login</source>
-        <extracomment>Accept button on dialog for submitting a Quick Connect code</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>To log a device in with Quick Connect, select the Quick Connect button and enter the displayed code in the field below.</source>
-        <extracomment>Instructions on page that tells the user a bit about how Quick Connect works</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/QuickConnectDialog.qml" line="81"/>
         <source>The Quick Connect code was not accepted</source>
         <extracomment>Error message shown below the textfield when it is not connected</extracomment>
         <translation type="unfinished"></translation>
@@ -467,6 +562,7 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>SeasonPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/SeasonPage.qml" line="143"/>
         <source>No overview available</source>
         <extracomment>No overview/summary text of an episode available</extracomment>
         <translation type="unfinished"></translation>
@@ -475,6 +571,7 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>SeriesPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/SeriesPage.qml" line="63"/>
         <source>Seasons</source>
         <extracomment>Seasons of a (TV) show</extracomment>
         <translation type="unfinished"></translation>
@@ -483,70 +580,84 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>SettingsPage</name>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="48"/>
         <source>Settings</source>
         <extracomment>Header of Settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Other</source>
-        <extracomment>Other settings menu item</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>About Sailfin</source>
-        <extracomment>About Sailfin settings menu itemy</extracomment>
-        <translation type="unfinished">About Sailfin</translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="53"/>
         <source>Session</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Log out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Logging out</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Streaming settings</source>
-        <extracomment>Settings list item for settings related to streaming</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Debug information</source>
-        <extracomment>Debug information settings menu itemy</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="112"/>
         <source>Quick Connect</source>
         <extracomment>This is a name used by Jellyfin and seems to be untranslated in other languages</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="116"/>
+        <source>Log out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="117"/>
+        <source>Logging out</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="123"/>
+        <source>Other</source>
+        <extracomment>Other settings menu item</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="136"/>
         <source>Start page</source>
         <extracomment>Combo box label for selecting where the application should start</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="138"/>
         <source>Which page should be shown when the application starts?</source>
         <extracomment>Combo box description for selecting where the application should start</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="143"/>
         <source>All libraries (default)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="185"/>
+        <source>Streaming settings</source>
+        <extracomment>Settings list item for settings related to streaming</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="192"/>
+        <source>Debug information</source>
+        <extracomment>Debug information settings menu itemy</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/SettingsPage.qml" line="199"/>
+        <source>About Sailfin</source>
+        <extracomment>About Sailfin settings menu itemy</extracomment>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SongDelegate</name>
     <message>
+        <location filename="../qml/components/music/SongDelegate.qml" line="119"/>
         <source>Go to %1</source>
         <extracomment>Context menu item for navigating to the artist of the selected track</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/music/SongDelegate.qml" line="122"/>
         <source>Go to artists</source>
         <extracomment>Context menu item for navigating to one of the artists of the selected track (opens submenu)</extracomment>
         <translation type="unfinished"></translation>
@@ -555,22 +666,27 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>StreamingPage</name>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="42"/>
         <source>Streaming settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="46"/>
         <source>Allow transcoding</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="47"/>
         <source>If enabled, Sailfin may request the Jellyfin server to transcode media to a more suitable media format for this device. It is recommended to leave this enabled unless your server is weak.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="58"/>
         <source>%1 mbps</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/settings/StreamingPage.qml" line="61"/>
         <source>Maximum streaming bitrate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -578,28 +694,33 @@ Placeholder text for textfield for entering the Quick Connect codeyy</extracomme
 <context>
     <name>UnsupportedPage</name>
     <message>
-        <source>Item type (%1) unsupported</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fallback page for %2 not found either
-This is still an alpha version :)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="35"/>
         <source>Settings</source>
         <extracomment>Pulley menu item: navigate to application settings page</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="40"/>
         <source>Remote control</source>
         <extracomment>Pulley menu item: shows controllable device page</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="47"/>
+        <source>Item type (%1) unsupported</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/pages/itemdetails/UnsupportedPage.qml" line="48"/>
+        <source>Fallback page for %2 not found either
+This is still an alpha version :)</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>UserGridDelegate</name>
     <message>
+        <location filename="../qml/components/UserGridDelegate.qml" line="51"/>
         <source>Other account</source>
         <translation type="unfinished"></translation>
     </message>
@@ -607,41 +728,49 @@ This is still an alpha version :)</source>
 <context>
     <name>VideoError</name>
     <message>
-        <source>Resource allocation error</source>
-        <extracomment>Video playback error: out of resources</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Video format unsupported</source>
-        <extracomment>Video playback error: unsupported format/codec</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Network error</source>
-        <extracomment>Video playback error: network error</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Access denied</source>
-        <extracomment>Video playback error: access denied</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Media service missing</source>
-        <extracomment>Video playback error: the media cannot be played because the media service could not be instantiated.</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Retry</source>
-        <extracomment>Button to retry loading a video after a failure</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="50"/>
         <source>No error</source>
         <extracomment>Just to be complete if the application shows a video playback error when there&apos;s no error.</extracomment>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="54"/>
+        <source>Resource allocation error</source>
+        <extracomment>Video playback error: out of resources</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="58"/>
+        <source>Video format unsupported</source>
+        <extracomment>Video playback error: unsupported format/codec</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="62"/>
+        <source>Network error</source>
+        <extracomment>Video playback error: network error</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="66"/>
+        <source>Access denied</source>
+        <extracomment>Video playback error: access denied</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="70"/>
+        <source>Media service missing</source>
+        <extracomment>Video playback error: the media cannot be played because the media service could not be instantiated.</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="89"/>
+        <source>Retry</source>
+        <extracomment>Button to retry loading a video after a failure</extracomment>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/videoplayer/VideoError.qml" line="94"/>
         <source>Hide</source>
         <translation type="unfinished"></translation>
     </message>
@@ -649,6 +778,7 @@ This is still an alpha version :)</source>
 <context>
     <name>VideoPage</name>
     <message>
+        <location filename="../qml/pages/itemdetails/VideoPage.qml" line="57"/>
         <source>Run time: %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -656,26 +786,31 @@ This is still an alpha version :)</source>
 <context>
     <name>VideoTrackSelector</name>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="47"/>
+        <source>Video track</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="62"/>
         <source>Audio track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="77"/>
         <source>Subtitle track</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../qml/components/VideoTrackSelector.qml" line="83"/>
         <source>Off</source>
         <extracomment>Value in ComboBox to disable subtitles</extracomment>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Video track</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>harbour-sailfin</name>
     <message>
+        <location filename="../qml/harbour-sailfin.qml" line="101"/>
         <source>Sailfin</source>
         <extracomment>The application name for the notification</extracomment>
         <translation type="unfinished"></translation>


### PR DESCRIPTION
I've dropped the whole `<constant> * Theme.pixelRatio`-approach[^1] for determining when the UI should split into two columns, because the values seemed quite arbitrary and I was entering random numbers. I'm now doing it on multiples of `Theme.itemSizeHuge`, which is easier to reason about.

This also fixes occasions where items in a grid would leave a bit of space to the right in the CollectionPage.

Backdrop images in VideoPage and MusicAlbumPage now have a maximum height of half of the screen, to avoid filling the entire screen in landscape mode. Perhaps it doesn't always look good, but it makes the layout more usable.

Images on the SeasonPage and MusicAlbumPage (in landscape) are now aligned to the right, to avoid blocking the Page back indicator.

The screen now should look like this: 
![afbeelding](https://github.com/heartfin/harbour-sailfin/assets/4262067/7325f255-81a1-4ff8-986e-8394724b964e)

Closes #43 

[^1]: Which I was doing wrong by the way, because I should multiply by the `Theme.pixelRatio`, not divide.