### PR TITLE
Update outdated PlaybackState enums in QML

### DIFF
--- a/sailfish/qml/components/videoplayer/VideoHud.qml
+++ b/sailfish/qml/components/videoplayer/VideoHud.qml
@@ -152,15 +152,10 @@ Item {
     Connections {
         target: manager
         onMediaStatusChanged: {
-            console.log("New mediaPlayer status: " + manager.mediaStatus)
-            switch(manager.mediaStatus) {
-            case J.MediaStatus.Loaded:
-            case J.MediaStatus.Buffering:
-                show(false)
-                break;
-            case J.MediaStatus.Buffered:
+            if (manager.mediaStatus == J.MediaStatus.Loaded || manager.mediaStatus == J.MediaStatus.Buffered) {
                 hide(false)
-                break;
+            } else if (manager.mediaStatus == J.MediaStatus.Buffering || manager.mediaStatus == J.MediaStatus.Stalled) {
+                show(false)
             }
         }
     }

--- a/sailfish/qml/harbour-sailfin.qml
+++ b/sailfish/qml/harbour-sailfin.qml
@@ -131,11 +131,11 @@ ApplicationWindow {
 
     // Keep the sytem alive while playing media
     KeepAlive {
-        enabled: playbackManager.playbackState === MediaPlayer.PlayingState
+        enabled: playbackManager.playbackState == PlayerState.Playing
     }
 
     DisplayBlanking {
-        preventBlanking: playbackManager.playbackState === MediaPlayer.PlayingState
+        preventBlanking: playbackManager.playbackState == PlayerState.Playing
                          && playbackManager.hasVideo
                          && playbackManager.controllingSessionLocal // Must be controlling a local session
     }


### PR DESCRIPTION
With the refractor in f91e9f8, an abstraction over QtMultiMedia was implemented. New enums for the PlaybackState were created, to not make the application depend on QtMultiMedia. However, not all code was updated to make proper use of these new enums.

This in turn caused the screen turned off while playing a video and the HUD not showing when the video started buffering. This commit fixes that.

Closes #51