### PR TITLE
build: produce static libraries

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -114,7 +114,7 @@ endif()
 
 
 
-add_library(JellyfinQt ${JellyfinQt_SOURCES} ${JellyfinQt_HEADERS} qmldir JellyfinQt.qmltypes)
+add_library(JellyfinQt STATIC ${JellyfinQt_SOURCES} ${JellyfinQt_HEADERS} qmldir JellyfinQt.qmltypes)
 
 if(${CMAKE_VERSION} VERSION_GREATER "3.16.0") 
     if(BUILD_PRECOMPILED_HEADERS)
@@ -164,6 +164,6 @@ add_custom_command(
 
 
 set(QML_IMPORT_PATH $<TARGET_FILE_DIR:JellyfinQt> CACHE PATH "")
-install(FILES $<TARGET_FILE_DIR:JellyfinQt>/qmldir DESTINATION ${CMAKE_INSTALL_LIBDIR})
+# install(FILES $<TARGET_FILE_DIR:JellyfinQt>/qmldir DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 export(TARGETS JellyfinQt FILE JellyfinQtConfig.cmake)

--- a/core/include/JellyfinQt/jellyfin.h
+++ b/core/include/JellyfinQt/jellyfin.h
@@ -28,6 +28,7 @@ class JellyfinPlugin : public QQmlExtensionPlugin {
     Q_OBJECT
     Q_PLUGIN_METADATA(IID QQmlExtensionInterface_iid)
 public:
+    explicit JellyfinPlugin(QObject *parent = nullptr);
     void registerTypes(const char *uri) override;
 
 };

--- a/core/src/jellyfin.cpp
+++ b/core/src/jellyfin.cpp
@@ -48,6 +48,12 @@
 
 namespace Jellyfin {
 
+JellyfinPlugin::JellyfinPlugin(QObject *parent)
+    : QQmlExtensionPlugin(parent)
+{
+
+}
+
 void JellyfinPlugin::registerTypes(const char *uri) {
     qmlRegisterType<ApiClient>(uri, 1, 0, "ApiClient");
     qmlRegisterType<ServerDiscoveryModel>(uri, 1, 0, "ServerDiscoveryModel");

--- a/sailfish/src/harbour-sailfin.cpp
+++ b/sailfish/src/harbour-sailfin.cpp
@@ -30,6 +30,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <QQuickView>
 #include <QQmlEngine>
 #include <QString>
+#include <JellyfinQt/jellyfin.h>
 
 #include <sailfishapp.h>
 
@@ -51,6 +52,9 @@ int main(int argc, char *argv[]) {
     app->setApplicationName("Sailfin");
     //: Application display name
     app->setApplicationDisplayName(QObject::tr("Sailfin"));
+
+    Jellyfin::JellyfinPlugin *plugin = new Jellyfin::JellyfinPlugin(app);
+    plugin->registerTypes("nl.netsoj.chris.Jellyfin");
 
     QCommandLineParser cmdParser;
     cmdParser.addHelpOption();


### PR DESCRIPTION
This also adds the constructor to the plugin class, as it should now be called to register the qml types.

Dynamic linking mostly has its problem on Sailfish OS, as it creates larger binaries and RPMs. Since this is the only application consuming it, I see no benefit in using it.